### PR TITLE
Update commons-math dependency.

### DIFF
--- a/caliper/pom.xml
+++ b/caliper/pom.xml
@@ -126,8 +126,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-math</artifactId>
-      <version>2.2</version>
+      <artifactId>commons-math3</artifactId>
+      <version>3.5</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.java-allocation-instrumenter</groupId>

--- a/caliper/src/main/java/com/google/caliper/runner/ConsoleOutput.java
+++ b/caliper/src/main/java/com/google/caliper/runner/ConsoleOutput.java
@@ -33,8 +33,8 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
 
-import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
-import org.apache.commons.math.stat.descriptive.rank.Percentile;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
 
 import java.io.Closeable;
 import java.io.PrintWriter;


### PR DESCRIPTION
Apache commons math has switched major version and updated it's
module namespace. This change updates the commons-math dependency
to the latest stable version and the import to match the new
location of the Percentile and DescriptiveStatistics location.

A casual look at the actual (minimal) usage of commons-math I'm convinced 
that them major version update will not affect our use case.
