### PR TITLE
Up jvm option CICompilerCount to 2, compat with version > 1.8.0_25

### DIFF
--- a/caliper/src/main/java/com/google/caliper/runner/Instrument.java
+++ b/caliper/src/main/java/com/google/caliper/runner/Instrument.java
@@ -153,7 +153,7 @@ public abstract class Instrument {
       // do compilation serially
       "-Xbatch",
       // make sure compilation doesn't run in parallel with itself
-      "-XX:CICompilerCount=1",
+      "-XX:CICompilerCount=2",
       // ensure the parallel garbage collector
       "-XX:+UseParallelGC",
       // generate classes or don't, but do it immediately


### PR DESCRIPTION
With jvm 1.8.0_40 (OSX) subprocess invocation fails with
"CICompilerCount of 1 is invalid; must be at least 2", so upping
to 2, and lo and behold, the unit tests work.