### PR TITLE
Caliper on Java 6 VM and ClassNotFound when using class defined on classpath.

### DIFF
--- a/caliper/pom.xml
+++ b/caliper/pom.xml
@@ -153,6 +153,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.18.1</version>
+        <configuration>
+            <argLine>-Xmx1024m</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>

--- a/caliper/src/main/java/com/google/caliper/config/CaliperConfig.java
+++ b/caliper/src/main/java/com/google/caliper/config/CaliperConfig.java
@@ -73,7 +73,7 @@ public final class CaliperConfig {
       Matcher matcher = CLASS_PROPERTY_PATTERN.matcher(entry.getKey());
       if (matcher.matches() && !entry.getValue().isEmpty()) {
         try {
-          Class<?> someClass = Class.forName(entry.getValue());
+          Class<?> someClass = Util.lookupClass(entry.getValue());
           checkState(type.isAssignableFrom(someClass));
           @SuppressWarnings("unchecked")
           Class<? extends T> verifiedClass = (Class<? extends T>) someClass;

--- a/caliper/src/main/java/com/google/caliper/runner/ExperimentModule.java
+++ b/caliper/src/main/java/com/google/caliper/runner/ExperimentModule.java
@@ -18,10 +18,15 @@ package com.google.caliper.runner;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.text.ParseException;
+
 import com.google.caliper.Param;
 import com.google.caliper.bridge.WorkerSpec;
 import com.google.caliper.util.Parser;
 import com.google.caliper.util.Parsers;
+import com.google.caliper.util.Util;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.inject.AbstractModule;
@@ -30,10 +35,6 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.matcher.AbstractMatcher;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.text.ParseException;
 
 /**
  * A module that binds data specific to a single experiment.
@@ -57,9 +58,8 @@ public final class ExperimentModule extends AbstractModule {
         experiment.userParameters());
   }
 
-  public static ExperimentModule forWorkerSpec(WorkerSpec spec)
-      throws ClassNotFoundException {
-    Class<?> benchmarkClass = Class.forName(spec.benchmarkSpec.className());
+  public static ExperimentModule forWorkerSpec(WorkerSpec spec) throws ClassNotFoundException {
+    final Class<?> benchmarkClass = Util.lookupClass(spec.benchmarkSpec.className());
     Method benchmarkMethod = findBenchmarkMethod(benchmarkClass, spec.benchmarkSpec.methodName(),
         spec.methodParameterClasses);
     benchmarkMethod.setAccessible(true);

--- a/caliper/src/main/java/com/google/caliper/util/Util.java
+++ b/caliper/src/main/java/com/google/caliper/util/Util.java
@@ -24,10 +24,14 @@ import com.google.common.io.ByteSource;
 import com.google.common.io.Closer;
 import com.google.common.io.Resources;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -35,6 +39,23 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public final class Util {
+
+  // lookupClass related fields.
+  private static final File ROOT = new File(".");
+  private static final URLClassLoader CLASS_LOADER;
+
+  private static URL[] urls;
+  static {
+    try {
+        urls = new URL[] { ROOT.toURI().toURL() };
+    } catch (MalformedURLException e) {
+        System.err.println("Could get root URI, class lookup via Util.lookupClass() will not work. root="+ROOT);
+        System.err.println(e);
+        urls = null;
+    }
+    CLASS_LOADER = URLClassLoader.newInstance(urls);
+  }
+
   private Util() {}
 
   // Users have no idea that nested classes are identified with '$', not '.', so if class lookup
@@ -124,5 +145,10 @@ public final class Util {
     } else {
       return generateUniqueName(index / 26 - 1) + generateUniqueName(index % 26);
     }
+  }
+
+  public static Class<?> lookupClass(String className) throws ClassNotFoundException {
+    final Class<?> clazz = Class.forName(className, true, CLASS_LOADER);
+    return clazz;
   }
 }

--- a/caliper/src/main/java/com/google/caliper/worker/AllocationRecorder.java
+++ b/caliper/src/main/java/com/google/caliper/worker/AllocationRecorder.java
@@ -25,12 +25,12 @@ package com.google.caliper.worker;
  */
 abstract class AllocationRecorder {
 
-  private final boolean LESS_THAN_JAVA_7 = System.getProperty("java.version").startsWith("1.5") || System.getProperty("java.version").startsWith("1.6");
+  private static final boolean LESS_THAN_JAVA_7 = System.getProperty("java.version").startsWith("1.5") || System.getProperty("java.version").startsWith("1.6");
 
   // (Java 1.7+)
   private boolean firstTime = true;
   {
-    // (Java 1.5, Java 1.6) Allocations seem somewhat non-deterministic is less than Java 7
+    // (Java 1.5, Java 1.6) Allocations seem somewhat non-deterministic, so disable
     if (LESS_THAN_JAVA_7)
         firstTime = false;
   }

--- a/caliper/src/main/java/com/google/caliper/worker/AllocationRecorder.java
+++ b/caliper/src/main/java/com/google/caliper/worker/AllocationRecorder.java
@@ -24,7 +24,17 @@ package com.google.caliper.worker;
  * thread.
  */
 abstract class AllocationRecorder {
+
+  private final boolean LESS_THAN_JAVA_7 = System.getProperty("java.version").startsWith("1.5") || System.getProperty("java.version").startsWith("1.6");
+
+  // (Java 1.7+)
   private boolean firstTime = true;
+  {
+    // (Java 1.5, Java 1.6) Allocations seem somewhat non-deterministic is less than Java 7
+    if (LESS_THAN_JAVA_7)
+        firstTime = false;
+  }
+
   
   /** 
    * Clears the prior state and starts a new recording.

--- a/caliper/src/main/java/com/google/caliper/worker/WorkerMain.java
+++ b/caliper/src/main/java/com/google/caliper/worker/WorkerMain.java
@@ -18,6 +18,9 @@ package com.google.caliper.worker;
 
 import static com.google.inject.Stage.PRODUCTION;
 
+import java.net.InetSocketAddress;
+import java.nio.channels.SocketChannel;
+
 import com.google.caliper.bridge.BridgeModule;
 import com.google.caliper.bridge.CommandLineSerializer;
 import com.google.caliper.bridge.OpenedSocket;
@@ -25,12 +28,10 @@ import com.google.caliper.bridge.ShouldContinueMessage;
 import com.google.caliper.bridge.WorkerSpec;
 import com.google.caliper.runner.BenchmarkClassModule;
 import com.google.caliper.runner.ExperimentModule;
+import com.google.caliper.util.Util;
 import com.google.common.net.InetAddresses;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-
-import java.net.InetSocketAddress;
-import java.nio.channels.SocketChannel;
 
 /**
  * This class is invoked as a subprocess by the Caliper runner parent process; it re-stages
@@ -49,8 +50,9 @@ public final class WorkerMain {
     channel.configureBlocking(false);
     channel.connect(new InetSocketAddress(InetAddresses.forString("127.0.0.1"), request.port));
 
+    final Class<?> clazz = Util.lookupClass(request.benchmarkSpec.className());
     Injector workerInjector = Guice.createInjector(PRODUCTION,
-        new BenchmarkClassModule(Class.forName(request.benchmarkSpec.className())),
+        new BenchmarkClassModule(clazz),
         new BridgeModule(),
         ExperimentModule.forWorkerSpec(request),
         new WorkerModule(request));

--- a/caliper/src/test/java/com/google/caliper/runner/AllocationInstrumentTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/AllocationInstrumentTest.java
@@ -67,13 +67,13 @@ public class AllocationInstrumentTest {
     Trial trial = Iterables.getOnlyElement(runner.trials());
     ImmutableListMultimap<String, Measurement> measurementsByDescription =
         Measurement.indexByDescription(trial.measurements());
-    // 14 objects and 1960 bytes are the known values for growing an ArrayList from 1 element to 100
+    // 12 objects and 1824 bytes are the known values for growing an ArrayList from 1 element to 100
     // elements
     for (Measurement objectMeasurement : measurementsByDescription.get("objects")) {
-      assertEquals(14.0, objectMeasurement.value().magnitude() / objectMeasurement.weight(), 0.001);
+      assertEquals(12.0, objectMeasurement.value().magnitude() / objectMeasurement.weight(), 0.001);
     }
     for (Measurement byteMeasurement : measurementsByDescription.get("bytes")) {
-      assertEquals(1960.0, byteMeasurement.value().magnitude() / byteMeasurement.weight(), 0.001);
+      assertEquals(1824.0, byteMeasurement.value().magnitude() / byteMeasurement.weight(), 0.001);
     }
   }
 

--- a/caliper/src/test/java/com/google/caliper/runner/AllocationInstrumentTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/AllocationInstrumentTest.java
@@ -41,7 +41,7 @@ import java.util.List;
 @RunWith(JUnit4.class)
 public class AllocationInstrumentTest {
 
-  private final boolean LESS_THAN_JAVA_7 = System.getProperty("java.version").startsWith("1.5") || System.getProperty("java.version").startsWith("1.6");
+  private static final boolean LESS_THAN_JAVA_7 = System.getProperty("java.version").startsWith("1.5") || System.getProperty("java.version").startsWith("1.6");
 
   // (Java 1.7+) 14 objects and 1960 bytes are the known values for growing an ArrayList from 1 element to 100 elements
   private double objects = 14.0;

--- a/caliper/src/test/java/com/google/caliper/runner/ServerSocketServiceTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/ServerSocketServiceTest.java
@@ -99,7 +99,7 @@ public class ServerSocketServiceTest {
   }
 
   private OpenedSocket openClientConnection() throws IOException {
-    return OpenedSocket.fromSocket(new Socket(InetAddress.getLoopbackAddress(), port));
+    return OpenedSocket.fromSocket(new Socket(InetAddress.getLocalHost(), port));
   }
 
   /**


### PR DESCRIPTION
Fixed a number of issues when using Caliper with a Java 6 VM (1.6.0_65):
 - ServerSocketServiceTest was using a java 7 only getLoopbackAddress() method
 - AllocationRecorder and AllocationInstrumentTest used values which weren't compatible

Fixed ClassNotFound exception when trying to load a class which was defined in a jar on the classpath (this is a java 6 & 7 problem, I believe):
 - WorkerMain
 - ExperimentModule
 - CaliperConfig