### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,9 @@ language: java
 jdk:
   - oraclejdk8
 
-before_install:
-  - MVN_VERSION=3.5.0
-  - wget https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.zip
-  - unzip -qq apache-maven-${MVN_VERSION}-bin.zip
-  - export M2_HOME=$PWD/apache-maven-${MVN_VERSION}
-  - export PATH=$M2_HOME/bin:$PATH
+install: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn install -U -DskipTests=true -am -pl caliper
 
-install: mvn -B install -U -DskipTests=true -am -pl caliper
-
-script: mvn -B verify -U -Dmaven.javadoc.skip=true -am -pl caliper
+script: mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn verify -U -Dmaven.javadoc.skip=true -am -pl caliper
 
 cache:
   directories:


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove stuff for downloading Maven 3.5.0 from Travis config; according to Travis, Maven 3.5.x is the default now.

Also suppress "Downloading/Downloaded ..." messages from Maven output like we did for Guava.

eebd2bd2dff1eb355856fbf3d92e6bce76866ffd