### PR TITLE
Moe Sync

### DIFF
--- a/caliper-core/src/main/java/com/google/caliper/memory/ObjectExplorer.java
+++ b/caliper-core/src/main/java/com/google/caliper/memory/ObjectExplorer.java
@@ -19,6 +19,7 @@ package com.google.caliper.memory;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
+import java.lang.ref.Reference;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -138,6 +139,10 @@ public final class ObjectExplorer {
         final Field[] fields = getAllFields(value);
         for (int j = fields.length - 1; j >= 0; j--) {
           final Field field = fields[j];
+          if (field.getDeclaringClass().equals(Reference.class)
+              && !field.getName().equals("referent")) {
+            continue;
+          }
           Object childValue = null;
           try {
             childValue = field.get(value);

--- a/caliper-core/src/test/java/com/google/caliper/memory/ObjectGraphMeasurerTest.java
+++ b/caliper-core/src/test/java/com/google/caliper/memory/ObjectGraphMeasurerTest.java
@@ -18,6 +18,7 @@ package com.google.caliper.memory;
 
 import com.google.caliper.memory.ObjectGraphMeasurer.Footprint;
 import com.google.common.collect.ImmutableMultiset;
+import java.lang.ref.WeakReference;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -141,6 +142,22 @@ public class ObjectGraphMeasurerTest extends TestCase {
   public void testNullField() {
     ObjectGraphMeasurer.Footprint footprint = ObjectGraphMeasurer.measure(oneNullOneNonNull);
     assertEquals(new ObjectGraphMeasurer.Footprint(2, 2, 3, NO_PRIMITIVES), footprint);
+  }
+
+  static final Object someObject = new Object();
+  static final WeakReference<Object> weakRef = new WeakReference<>(someObject);
+
+  /**
+   * Test that we still follow the main {@code referent} field of a {@link WeakReference}, even as
+   * we ignore its other fields.
+   *
+   * <p>(It's more difficult to test that we are in fact ignoring its other fields. We could
+   * probably do it, but we sort of have a test already because this fixes a flaky test in Guava.)
+   */
+  @Test
+  public void testWeakReference() {
+    ObjectGraphMeasurer.Footprint footprint = ObjectGraphMeasurer.measure(weakRef);
+    assertEquals(new ObjectGraphMeasurer.Footprint(2, 1, 0, NO_PRIMITIVES), footprint);
   }
 
   private static final ImmutableMultiset<Class<?>> NO_PRIMITIVES = ImmutableMultiset.of();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't follow internal fields on java.lang.ref.Reference.

They can contain arbitrary other Reference objects, put there by the GC as it collects weak, etc. references.
(See Reference for its `next`, `discovered`, and probably `queue` fields, apparently maipulated from hotspot/src/share/vm/memory/referenceProcessor.cpp)

This causes us to overcount in some cases by visiting those extra objects, resulting in flaky failures of Guava's CacheMemoryConsumptionTest.
Under JDK9, it sometimes causes exceptions as we try to visit objects in private modules, e.g.,
  java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.Runnable jdk.internal.ref.CleanerImpl$PhantomCleanableRef.action accessible: module java.base does not "opens jdk.internal.ref" to unnamed module @277a637a; did you mean --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
(It's possible that we'll also want to modify this code to be able to visit objects in private modules someday. If so, we can do it with Unsafe.)

(Note that it's potentially still nondeterministic to ask for the size of an object that contains weak, etc. references, since some of those references could disappear during the traversal (especially since we're allocating objects, like arrays of Field instances). Code that wants to do this has to be careful to keep the referenced objects alive in some way, as Guava CacheMemoryConsumptionTest does.)

RELNOTES=Started ignoring internal fields of `java.lang.ref.Reference`, which can contain unrelated objects (especially problematic when the objects are from inaccessible modules).

d3fcaa4b80325a94af0465b3309f015403d7d726