### PR TITLE
Moe Sync

### DIFF
--- a/caliper-core/src/main/java/com/google/caliper/bridge/LogMessageParserModule.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/LogMessageParserModule.java
@@ -23,6 +23,8 @@ import dagger.Module;
 /** Binds {@link Parser Parser&lt;LogMessage&gt;} to {@link LogMessageParser}. */
 @Module
 public abstract class LogMessageParserModule {
+  private LogMessageParserModule() {}
+
   @Binds
   abstract Parser<LogMessage> provideLogMessageParser(LogMessageParser parser);
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunModule.java
@@ -28,6 +28,7 @@ import dagger.Provides;
 /** Configures the {@link CaliperRun}. */
 @Module(subcomponents = {DryRunComponent.class, TrialComponent.class})
 abstract class CaliperRunModule {
+  private CaliperRunModule() {}
 
   @Provides
   static CaliperRun provideCaliperRun(ExperimentingCaliperRun experimentingCaliperRun) {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
@@ -59,6 +59,7 @@ import org.joda.time.Instant;
   subcomponents = {BenchmarkModelComponent.class, CaliperRunComponent.class}
 )
 abstract class CaliperRunnerModule {
+  private CaliperRunnerModule() {}
 
   private static final String RUNNER_MAX_PARALLELISM_OPTION = "runner.maxParallelism";
 

--- a/caliper-runner/src/main/java/com/google/caliper/runner/HostModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/HostModule.java
@@ -38,6 +38,7 @@ import java.util.TreeMap;
  */
 @Module
 abstract class HostModule {
+  private HostModule() {}
 
   @Provides
   @RunScoped

--- a/caliper-runner/src/main/java/com/google/caliper/runner/ServiceModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/ServiceModule.java
@@ -26,6 +26,8 @@ import javax.inject.Singleton;
 /** Configures the {@link ServiceManager}. */
 @Module
 abstract class ServiceModule {
+  private ServiceModule() {}
+
   @Provides
   @Singleton
   static ServiceManager provideServiceManager(Set<Service> services) {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfigModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfigModule.java
@@ -35,6 +35,7 @@ import javax.inject.Singleton;
 /** Provides {@link CaliperConfig}. */
 @Module
 public abstract class CaliperConfigModule {
+  private CaliperConfigModule() {}
 
   @Provides
   @Singleton

--- a/caliper-runner/src/main/java/com/google/caliper/runner/instrument/InstrumentModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/instrument/InstrumentModule.java
@@ -47,6 +47,7 @@ import javax.inject.Provider;
 /** Configures the {@link Instrument}s for a Caliper run. */
 @Module(includes = NanoTimeGranularityModule.class)
 public abstract class InstrumentModule {
+  private InstrumentModule() {}
 
   /**
    * Specifies the {@link Class} object to use as a key in the map of available {@link Instrument

--- a/caliper-runner/src/main/java/com/google/caliper/runner/instrument/NanoTimeGranularityModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/instrument/NanoTimeGranularityModule.java
@@ -34,6 +34,8 @@ import dagger.Provides;
  */
 @Module
 public abstract class NanoTimeGranularityModule {
+  private NanoTimeGranularityModule() {}
+
   private static final int TRIALS = 1000;
 
   @Provides

--- a/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/ResultProcessorModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/ResultProcessorModule.java
@@ -30,6 +30,7 @@ import javax.inject.Provider;
 /** Configures the {@link ResultProcessor}s for a Caliper run. */
 @Module
 public abstract class ResultProcessorModule {
+  private ResultProcessorModule() {}
 
   /**
    * Specifies the {@link Class} object to use as a key in the map of available {@link

--- a/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerModule.java
@@ -25,6 +25,7 @@ import dagger.multibindings.IntoSet;
 /** Configures the {@link ServerSocketService}. */
 @Module
 public abstract class ServerModule {
+  private ServerModule() {}
 
   @Binds
   @IntoSet

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 /** Module for providing the {@link Device}. */
 @Module
 public abstract class DeviceModule {
+  private DeviceModule() {}
 
   @Provides
   static DeviceConfig provideDeviceConfig(CaliperOptions options, CaliperConfig config) {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/TargetModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/TargetModule.java
@@ -28,7 +28,6 @@ import dagger.Provides;
  */
 @Module
 public abstract class TargetModule {
-
   private TargetModule() {}
 
   @Provides

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/WorkerModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/WorkerModule.java
@@ -33,6 +33,7 @@ import dagger.Provides;
  */
 @Module
 public abstract class WorkerModule {
+  private WorkerModule() {}
 
   @WorkerScoped
   @Provides

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/WorkerOutputModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/WorkerOutputModule.java
@@ -24,6 +24,8 @@ import dagger.multibindings.IntoSet;
 /** Configures the {@link WorkerOutputFactory}. */
 @Module
 public abstract class WorkerOutputModule {
+  private WorkerOutputModule() {}
+
   @Binds
   @IntoSet
   abstract Service bindWorkerOutputFactoryService(WorkerOutputFactoryService impl);

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelModule.java
@@ -26,6 +26,8 @@ import dagger.Module;
 /** Module with bindings needed for getting a benchmark model from a worker. */
 @Module(includes = WorkerModule.class)
 abstract class BenchmarkModelModule {
+  private BenchmarkModelModule() {}
+
   @Binds
   abstract WorkerProcessor<BenchmarkClassModel> bindWorkerProcessor(
       BenchmarkModelWorkerProcessor processor);

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelWorkerSpec.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelWorkerSpec.java
@@ -56,7 +56,7 @@ final class BenchmarkModelWorkerSpec extends WorkerSpec {
   public ImmutableList<String> additionalVmOptions() {
     // Use a relatively low heap size since nothing the worker does should require much memory.
     // These go after the default options, so they'll override them.
-    return ImmutableList.of("-Xms32m", "-Xmx128m");
+    return ImmutableList.of("-Xms32m", "-Xmx512m");
   }
 
   @Override

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelWorkerSpec.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/benchmarkmodel/BenchmarkModelWorkerSpec.java
@@ -56,7 +56,7 @@ final class BenchmarkModelWorkerSpec extends WorkerSpec {
   public ImmutableList<String> additionalVmOptions() {
     // Use a relatively low heap size since nothing the worker does should require much memory.
     // These go after the default options, so they'll override them.
-    return ImmutableList.of("-Xms256m", "-Xmx1g");
+    return ImmutableList.of("-Xms32m", "-Xmx128m");
   }
 
   @Override

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/dryrun/DryRunModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/dryrun/DryRunModule.java
@@ -39,6 +39,7 @@ import java.util.Set;
  */
 @Module(includes = WorkerModule.class)
 abstract class DryRunModule {
+  private DryRunModule() {}
 
   @Provides
   @Reusable

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialModule.java
@@ -39,6 +39,7 @@ import java.util.UUID;
 /** Configuration for running a trial. */
 @ProducerModule(includes = WorkerModule.class)
 abstract class TrialModule {
+  private TrialModule() {}
 
   @Produces
   static TrialResult trialResult(WorkerRunner<TrialResult> trialResultWorkerRunner) {

--- a/caliper-util/src/main/java/com/google/caliper/json/GsonModule.java
+++ b/caliper-util/src/main/java/com/google/caliper/json/GsonModule.java
@@ -34,6 +34,7 @@ import org.joda.time.Instant;
  */
 @Module
 public abstract class GsonModule {
+  private GsonModule() {}
 
   @Binds
   @IntoSet

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/AndroidWorkerModule.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/AndroidWorkerModule.java
@@ -27,6 +27,8 @@ import dagger.Module;
  */
 @Module(subcomponents = AndroidWorkerInstrumentComponent.class)
 abstract class AndroidWorkerModule {
+  private AndroidWorkerModule() {}
+
   @Binds
   abstract WorkerInstrumentComponent.Builder bindInstrumentComponentBuilder(
       AndroidWorkerInstrumentComponent.Builder builder);

--- a/caliper-worker-jvm/src/main/java/com/google/caliper/worker/JvmWorkerInstrumentModule.java
+++ b/caliper-worker-jvm/src/main/java/com/google/caliper/worker/JvmWorkerInstrumentModule.java
@@ -29,6 +29,7 @@ import javax.inject.Provider;
 /** Module providing worker instruments that should only be present when running on the JVM. */
 @Module
 abstract class JvmWorkerInstrumentModule {
+  private JvmWorkerInstrumentModule() {}
 
   @Binds
   @IntoMap

--- a/caliper-worker-jvm/src/main/java/com/google/caliper/worker/JvmWorkerModule.java
+++ b/caliper-worker-jvm/src/main/java/com/google/caliper/worker/JvmWorkerModule.java
@@ -27,6 +27,8 @@ import dagger.Module;
  */
 @Module(subcomponents = JvmWorkerInstrumentComponent.class)
 abstract class JvmWorkerModule {
+  private JvmWorkerModule() {}
+
   @Binds
   abstract WorkerInstrumentComponent.Builder bindInstrumentComponentBuilder(
       JvmWorkerInstrumentComponent.Builder builder);

--- a/caliper-worker/src/main/java/com/google/caliper/worker/WorkerModule.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/WorkerModule.java
@@ -38,6 +38,7 @@ import javax.inject.Singleton;
  */
 @Module(includes = {WorkerOptionsModule.class, RequestHandlerModule.class})
 abstract class WorkerModule {
+  private WorkerModule() {}
 
   @Provides
   @Singleton

--- a/caliper-worker/src/main/java/com/google/caliper/worker/handler/RequestHandlerModule.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/handler/RequestHandlerModule.java
@@ -31,6 +31,7 @@ import dagger.multibindings.IntoMap;
  */
 @Module
 public abstract class RequestHandlerModule {
+  private RequestHandlerModule() {}
 
   @Binds
   @IntoMap

--- a/caliper-worker/src/main/java/com/google/caliper/worker/instrument/WorkerInstrumentModule.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/instrument/WorkerInstrumentModule.java
@@ -50,6 +50,7 @@ import javax.inject.Provider;
  */
 @Module
 public abstract class WorkerInstrumentModule {
+  private WorkerInstrumentModule() {}
 
   @Provides
   static BenchmarkSpec provideBenchmarkSpec(ExperimentSpec experiment) {

--- a/caliper/src/main/java/com/google/caliper/runner/JvmRunnerModule.java
+++ b/caliper/src/main/java/com/google/caliper/runner/JvmRunnerModule.java
@@ -28,6 +28,7 @@ import dagger.multibindings.IntoMap;
  */
 @Module
 abstract class JvmRunnerModule {
+  private JvmRunnerModule() {}
 
   @Provides
   @IntoMap


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add a private constructor to abstract Caliper modules.

392537e74a91c0f6b12fdaef2fd298a87c8e9586

-------

<p> Reduce the max heap for benchmark model workers; it didn't need to be as high as it was, and that caused issues for Android devices.

84d1cf625ff01140bcfa2c7f1d2207b165966de5

-------

<p> Increase the max heap for benchmark model workers, but not as high as it was before.

I'd wrongly assumed that since we don't run any benchmark code, the amount of memory required should be consistent across all benchmarks. But code actually can get run when the benchmark class is initialized (static fields/initializers). I'll have to think about how to deal with that.

355942de1f4794ad01d957da8e4d022018b7ddab