### PR TITLE
Moe Sync

### DIFF
--- a/caliper-android/src/main/java/com/google/caliper/runner/CaliperActivity.java
+++ b/caliper-android/src/main/java/com/google/caliper/runner/CaliperActivity.java
@@ -149,7 +149,7 @@ public final class CaliperActivity extends Activity {
   }
 
   private CaliperRunner createCaliperRunner(String[] args) throws IOException {
-    String classpathConfig = "-Candroid.worker.classpath=" + getClasspath();
+    String classpathConfig = "--worker-classpath-android=" + getClasspath();
     args = ObjectArrays.concat(args, classpathConfig);
     return DaggerAndroidCaliperRunnerComponent.builder()
         .optionsModule(OptionsModule.withBenchmarkClass(args))

--- a/caliper-android/src/main/resources/com/google/caliper/runner/config/global-config.properties
+++ b/caliper-android/src/main/resources/com/google/caliper/runner/config/global-config.properties
@@ -7,6 +7,7 @@
 
 device.local.type=local
 device.local.options.defaultVmType=android
+device.local.options.vmBaseDirectory=/system
 
 ######################
 # VM CONFIGURATION

--- a/caliper-api/src/main/java/com/google/caliper/model/Host.java
+++ b/caliper-api/src/main/java/com/google/caliper/model/Host.java
@@ -110,7 +110,7 @@ public final class Host {
       return this;
     }
 
-    public Builder addAllProperies(Map<String, String> properties) {
+    public Builder addAllProperties(Map<String, String> properties) {
       this.properties.putAll(properties);
       return this;
     }

--- a/caliper-core/src/main/java/com/google/caliper/bridge/AbstractLogMessageVisitor.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/AbstractLogMessageVisitor.java
@@ -43,7 +43,7 @@ public abstract class AbstractLogMessageVisitor implements LogMessageVisitor {
   public void visit(VmPropertiesLogMessage logMessage) {}
 
   @Override
-  public void visit(BenchmarkModelLogMessage logMessage) {}
+  public void visit(TargetInfoLogMessage logMessage) {}
 
   @Override
   public void visit(DryRunSuccessLogMessage logMessage) {}

--- a/caliper-core/src/main/java/com/google/caliper/bridge/LogMessageVisitor.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/LogMessageVisitor.java
@@ -32,7 +32,7 @@ public interface LogMessageVisitor {
 
   void visit(VmPropertiesLogMessage logMessage);
 
-  void visit(BenchmarkModelLogMessage logMessage);
+  void visit(TargetInfoLogMessage logMessage);
 
   void visit(DryRunSuccessLogMessage logMessage);
 }

--- a/caliper-core/src/main/java/com/google/caliper/bridge/TargetInfoLogMessage.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/TargetInfoLogMessage.java
@@ -18,24 +18,35 @@ package com.google.caliper.bridge;
 
 import com.google.auto.value.AutoValue;
 import com.google.caliper.core.BenchmarkClassModel;
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
+import java.util.Map;
 
 /**
- * A log message containing a {@link BenchmarkClassModel}.
+ * A log message containing the response to a {@link TargetInfoRequest}.
  *
  * @author Colin Decker
  */
 @AutoValue
-public abstract class BenchmarkModelLogMessage extends LogMessage implements Serializable {
+public abstract class TargetInfoLogMessage extends LogMessage implements Serializable {
   private static final long serialVersionUID = 1L;
 
-  /** Creates a new log message containing the given benchmark model. */
-  public static BenchmarkModelLogMessage create(BenchmarkClassModel model) {
-    return new AutoValue_BenchmarkModelLogMessage(model);
+  /** Creates a new log message containing the given benchmark model and device properties. */
+  public static TargetInfoLogMessage create(
+      BenchmarkClassModel model, Map<String, String> deviceProperties) {
+    return new AutoValue_TargetInfoLogMessage(model, ImmutableMap.copyOf(deviceProperties));
   }
 
   /** Returns the benchmark class model. */
   public abstract BenchmarkClassModel model();
+
+  /**
+   * Returns the properties of the target device that will be used to populate the {@code Host}
+   * associated with this target. The data included here will be available in the webapp for viewing
+   * and comparison (when viewing data taken from multiple devices, such as when comparing multiple
+   * runs).
+   */
+  public abstract ImmutableMap<String, String> deviceProperties();
 
   @Override
   public void accept(LogMessageVisitor visitor) {

--- a/caliper-core/src/main/java/com/google/caliper/bridge/TargetInfoRequest.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/TargetInfoRequest.java
@@ -16,35 +16,29 @@
 
 package com.google.caliper.bridge;
 
-import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 
 /**
- * {@link WorkerRequest} for telling a worker to send the runner a model of the benchmark class.
+ * {@link WorkerRequest} for telling a worker to send the runner information on the target it's
+ * running on, including a model of the benchmark class it produced.
  *
  * @author Colin Decker
  */
 @AutoValue
-public abstract class BenchmarkModelRequest implements WorkerRequest {
+public abstract class TargetInfoRequest implements WorkerRequest {
   private static final long serialVersionUID = 1L;
 
-  public static BenchmarkModelRequest create(
-      String benchmarkClass, Multimap<String, String> userParameters) {
-    checkArgument(!benchmarkClass.isEmpty());
-    return new AutoValue_BenchmarkModelRequest(
-        benchmarkClass, ImmutableSetMultimap.copyOf(userParameters));
+  public static TargetInfoRequest create(Multimap<String, String> userParameters) {
+    return new AutoValue_TargetInfoRequest(ImmutableSetMultimap.copyOf(userParameters));
   }
 
   @Override
   public final Class<? extends WorkerRequest> type() {
-    return BenchmarkModelRequest.class;
+    return TargetInfoRequest.class;
   }
-
-  /** Returns the name of the benchmark class to get the model of. */
-  public abstract String benchmarkClass();
 
   /**
    * Returns the parameters and their values that user provided for the benchmark, to be validated.

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunComponent.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunComponent.java
@@ -16,9 +16,9 @@
 
 package com.google.caliper.runner;
 
-import com.google.caliper.core.BenchmarkClassModel;
 import com.google.caliper.runner.instrument.InstrumentModule;
 import com.google.caliper.runner.resultprocessor.ResultProcessorModule;
+import com.google.caliper.runner.worker.targetinfo.TargetInfo;
 import dagger.BindsInstance;
 import dagger.Subcomponent;
 
@@ -27,7 +27,6 @@ import dagger.Subcomponent;
 @Subcomponent(
   modules = {
     CaliperRunModule.class,
-    HostModule.class,
     InstrumentModule.class,
     ResultProcessorModule.class
   }
@@ -41,7 +40,7 @@ interface CaliperRunComponent {
   @Subcomponent.Builder
   interface Builder {
     @BindsInstance
-    Builder benchmarkClassModel(BenchmarkClassModel model);
+    Builder targetInfo(TargetInfo info);
 
     /**  Builds a new {@link CaliperRunComponent}. */
     CaliperRunComponent build();

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunModule.java
@@ -17,10 +17,14 @@
 package com.google.caliper.runner;
 
 import com.google.caliper.core.BenchmarkClassModel;
+import com.google.caliper.model.Host;
 import com.google.caliper.runner.experiment.BenchmarkParameters;
 import com.google.caliper.runner.options.CaliperOptions;
+import com.google.caliper.runner.target.Target;
 import com.google.caliper.runner.worker.dryrun.DryRunComponent;
+import com.google.caliper.runner.worker.targetinfo.TargetInfo;
 import com.google.caliper.runner.worker.trial.TrialComponent;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import dagger.Module;
 import dagger.Provides;
@@ -40,5 +44,15 @@ abstract class CaliperRunModule {
   static ImmutableSetMultimap<String, String> provideBenchmarkParameters(
       BenchmarkClassModel benchmarkClass, CaliperOptions options) {
     return benchmarkClass.fillInDefaultParameterValues(options.userParameters());
+  }
+
+  @Provides
+  static BenchmarkClassModel provideBenchmarkClassModel(TargetInfo targetInfo) {
+    return targetInfo.benchmarkClassModel();
+  }
+
+  @Provides
+  static ImmutableMap<Target, Host> provideTargetHosts(TargetInfo targetInfo) {
+    return targetInfo.hosts();
   }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
@@ -28,9 +28,9 @@ import com.google.caliper.runner.server.ServerModule;
 import com.google.caliper.runner.target.DeviceModule;
 import com.google.caliper.runner.target.TargetModule;
 import com.google.caliper.runner.worker.WorkerOutputModule;
-import com.google.caliper.runner.worker.benchmarkmodel.BenchmarkModelComponent;
-import com.google.caliper.runner.worker.benchmarkmodel.BenchmarkModelFactory;
-import com.google.caliper.runner.worker.benchmarkmodel.BenchmarkModelFromWorkerFactory;
+import com.google.caliper.runner.worker.targetinfo.TargetInfoComponent;
+import com.google.caliper.runner.worker.targetinfo.TargetInfoFactory;
+import com.google.caliper.runner.worker.targetinfo.TargetInfoFromWorkerFactory;
 import com.google.caliper.util.OutputModule;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -56,7 +56,7 @@ import org.joda.time.Instant;
     TargetModule.class,
     WorkerOutputModule.class
   },
-  subcomponents = {BenchmarkModelComponent.class, CaliperRunComponent.class}
+  subcomponents = {TargetInfoComponent.class, CaliperRunComponent.class}
 )
 abstract class CaliperRunnerModule {
   private CaliperRunnerModule() {}
@@ -87,7 +87,7 @@ abstract class CaliperRunnerModule {
   }
 
   @Binds
-  abstract BenchmarkModelFactory bindModelFactory(BenchmarkModelFromWorkerFactory factory);
+  abstract TargetInfoFactory bindTargetInfoFactory(TargetInfoFromWorkerFactory factory);
 
   @Provides
   @BenchmarkClass

--- a/caliper-runner/src/main/java/com/google/caliper/runner/options/CaliperOptions.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/options/CaliperOptions.java
@@ -15,6 +15,7 @@
 package com.google.caliper.runner.options;
 
 import com.google.caliper.util.ShortDuration;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -65,6 +66,9 @@ public interface CaliperOptions {
    */
   // TODO(cgdecker): Either remove this or make it work
   ImmutableSetMultimap<String, String> vmArguments();
+
+  /** Returns the worker classpath to use for the given VM type. */
+  Optional<String> workerClasspath(String vmType);
 
   /**
    * Returns additional Caliper configuration properties to be merged with the properties in the

--- a/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
@@ -212,6 +212,9 @@ public final class ParsedOptions implements CaliperOptions {
 
   @Option({"-e", "--device"})
   private void setDeviceName(String deviceName) {
+    if (deviceName.indexOf('@') != -1) {
+      throw new InvalidCommandException("device names may not contain '@': %s", deviceName);
+    }
     this.deviceName = deviceName;
   }
 
@@ -230,6 +233,11 @@ public final class ParsedOptions implements CaliperOptions {
   private void setVms(String vmsString) throws InvalidCommandException {
     dryRunIncompatible("vm");
     vmNames = split(vmsString);
+    for (String name : vmNames) {
+      if (name.indexOf('@') != -1) {
+        throw new InvalidCommandException("VM names may not contain '@': %s", name);
+      }
+    }
   }
 
   @Override

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/AndroidDeviceHelper.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/AndroidDeviceHelper.java
@@ -18,10 +18,10 @@ package com.google.caliper.runner.target;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.caliper.runner.config.CaliperConfig;
 import com.google.caliper.runner.config.InvalidConfigurationException;
 import com.google.caliper.runner.config.VmConfig;
 import com.google.caliper.runner.config.VmType;
+import com.google.caliper.runner.options.CaliperOptions;
 import java.io.File;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -29,12 +29,12 @@ import javax.annotation.Nullable;
 /** Helper for when the local device is an Android device. */
 final class AndroidDeviceHelper implements LocalDevice.Helper {
 
-  private final CaliperConfig caliperConfig;
+  private final CaliperOptions options;
 
   @Nullable private volatile String androidDataDir = null;
 
-  AndroidDeviceHelper(CaliperConfig caliperConfig) {
-    this.caliperConfig = checkNotNull(caliperConfig);
+  AndroidDeviceHelper(CaliperOptions options) {
+    this.options = checkNotNull(options);
   }
 
   @Override
@@ -74,7 +74,8 @@ final class AndroidDeviceHelper implements LocalDevice.Helper {
     if (type.equals(VmType.JVM)) {
       throw new InvalidConfigurationException("can't run a JVM on Android");
     }
-    return caliperConfig.properties().get("android.worker.classpath");
+    // Guaranteed to be present since we explicitly set this in CaliperActivity
+    return options.workerClasspath(type.toString()).get();
   }
 
   @Override

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/AndroidVm.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/AndroidVm.java
@@ -16,8 +16,7 @@
 
 package com.google.caliper.runner.target;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
+import com.google.auto.value.AutoValue;
 import com.google.caliper.runner.config.VmConfig;
 import com.google.caliper.runner.config.VmType;
 import com.google.common.base.Predicate;
@@ -26,17 +25,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /** An Android VM, e.g. Dalvik or ART. */
-public final class AndroidVm extends Vm {
+@AutoValue
+public abstract class AndroidVm extends Vm {
 
-  AndroidVm(VmConfig config, String classpath) {
-    super(config, classpath);
-    checkArgument(config.type().get().equals(VmType.ANDROID), "config must have type android");
+  /** Creates a new {@link AndroidVm} for the given configuration. */
+  public static AndroidVm create(VmConfig config, String classpath) {
+    return new AutoValue_AndroidVm(VmType.ANDROID, config, classpath);
   }
 
-  @Override
-  public VmType type() {
-    return VmType.ANDROID;
-  }
+  AndroidVm() {}
 
   @Override
   public String executable() {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/Device.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/Device.java
@@ -69,9 +69,9 @@ public abstract class Device extends AbstractIdleService {
     String classpath = workerClasspath(type);
     switch (type) {
       case JVM:
-        return new Jvm(vmConfig, classpath);
+        return Jvm.create(vmConfig, classpath);
       case ANDROID:
-        return new AndroidVm(vmConfig, classpath);
+        return AndroidVm.create(vmConfig, classpath);
     }
     throw new AssertionError(type);
   }
@@ -112,4 +112,9 @@ public abstract class Device extends AbstractIdleService {
   /** Implements {@link #startVm}. */
   protected abstract VmProcess doStartVm(VmProcess.Spec spec, VmProcess.Logger logger)
       throws Exception;
+
+  @Override
+  public String toString() {
+    return name();
+  }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/Jvm.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/Jvm.java
@@ -16,6 +16,7 @@
 
 package com.google.caliper.runner.target;
 
+import com.google.auto.value.AutoValue;
 import com.google.caliper.runner.config.VmConfig;
 import com.google.caliper.runner.config.VmType;
 import com.google.common.annotations.VisibleForTesting;
@@ -24,7 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /** A standard Java Virtual Machine. */
-public final class Jvm extends Vm {
+@AutoValue
+public abstract class Jvm extends Vm {
 
   @VisibleForTesting
   public static final ImmutableSet<String> TRIAL_VM_ARGS =
@@ -58,14 +60,11 @@ public final class Jvm extends Vm {
       };
 
   /** Creates a new {@link Jvm} for the given configuration. */
-  public Jvm(VmConfig config, String classpath) {
-    super(config, classpath);
+  public static Jvm create(VmConfig config, String classpath) {
+    return new AutoValue_Jvm(VmType.JVM, config, classpath);
   }
 
-  @Override
-  public VmType type() {
-    return VmType.JVM;
-  }
+  Jvm() {}
 
   @Override
   public String executable() {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/LocalDevice.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/LocalDevice.java
@@ -22,6 +22,8 @@ import com.google.caliper.runner.config.CaliperConfig;
 import com.google.caliper.runner.config.DeviceConfig;
 import com.google.caliper.runner.config.VmConfig;
 import com.google.caliper.runner.config.VmType;
+import com.google.caliper.runner.options.CaliperOptions;
+import com.google.caliper.runner.options.ParsedOptions;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -58,20 +60,24 @@ public final class LocalDevice extends Device {
   LocalDevice(
       DeviceConfig config,
       CaliperConfig caliperConfig,
+      CaliperOptions caliperOptions,
       ShutdownHookRegistrar shutdownHookRegistrar) {
-    this(config, caliperConfig, shutdownHookRegistrar, false);
+    this(config, caliperConfig, caliperOptions, shutdownHookRegistrar, false);
   }
 
   private LocalDevice(
       DeviceConfig config,
       CaliperConfig caliperConfig,
+      CaliperOptions caliperOptions,
       ShutdownHookRegistrar shutdownHookRegistrar,
       boolean redirectErrorStream) {
     super(config, shutdownHookRegistrar);
     this.caliperConfig = caliperConfig;
     this.redirectErrorStream = redirectErrorStream;
     this.helper =
-        isAndroidDevice() ? new AndroidDeviceHelper(caliperConfig) : new NonAndroidDeviceHelper();
+        isAndroidDevice()
+            ? new AndroidDeviceHelper(caliperOptions)
+            : new NonAndroidDeviceHelper(caliperOptions);
   }
 
   @Override
@@ -265,6 +271,7 @@ public final class LocalDevice extends Device {
   public static final class Builder {
     private DeviceConfig deviceConfig;
     private CaliperConfig caliperConfig;
+    private CaliperOptions caliperOptions;
     private ShutdownHookRegistrar shutdownHookRegistrar;
     private boolean redirectErrorStream = false;
 
@@ -277,6 +284,12 @@ public final class LocalDevice extends Device {
     /** Sets the {@link CaliperConfig} to use. */
     public Builder caliperConfig(CaliperConfig caliperConfig) {
       this.caliperConfig = checkNotNull(caliperConfig);
+      return this;
+    }
+
+    /** Sets the {@link CaliperOptions} to use. */
+    public Builder caliperOptions(CaliperOptions caliperOptions) {
+      this.caliperOptions = checkNotNull(caliperOptions);
       return this;
     }
 
@@ -300,11 +313,14 @@ public final class LocalDevice extends Device {
       if (deviceConfig == null) {
         deviceConfig = caliperConfig.getDeviceConfig("local");
       }
+      if (caliperOptions == null) {
+        caliperOptions = ParsedOptions.from(new String[] {}, false);
+      }
       if (shutdownHookRegistrar == null) {
         shutdownHookRegistrar = new RuntimeShutdownHookRegistrar();
       }
       return new LocalDevice(
-          deviceConfig, caliperConfig, shutdownHookRegistrar, redirectErrorStream);
+          deviceConfig, caliperConfig, caliperOptions, shutdownHookRegistrar, redirectErrorStream);
     }
   }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/TargetModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/TargetModule.java
@@ -20,6 +20,7 @@ import com.google.caliper.runner.options.CaliperOptions;
 import com.google.common.collect.ImmutableSet;
 import dagger.Module;
 import dagger.Provides;
+import javax.inject.Singleton;
 
 /**
  * Module for binding the targets that Caliper should run the benchmark on.
@@ -30,6 +31,7 @@ import dagger.Provides;
 public abstract class TargetModule {
   private TargetModule() {}
 
+  @Singleton
   @Provides
   static ImmutableSet<Target> provideTargets(
       Device device, CaliperOptions options, CaliperConfig config) {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/Vm.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/Vm.java
@@ -16,8 +16,6 @@
 
 package com.google.caliper.runner.target;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.caliper.runner.config.VmConfig;
 import com.google.caliper.runner.config.VmType;
 import com.google.common.base.Optional;
@@ -28,30 +26,23 @@ import com.google.common.collect.ImmutableSet;
 /** Abstraction of a VM of a specific type with a specific configuration. */
 public abstract class Vm {
 
-  private final VmConfig config;
-  private final String classpath;
-
-  Vm(VmConfig config, String classpath) {
-    this.config = checkNotNull(config);
-    this.classpath = checkNotNull(classpath);
-  }
-
-  /** Returns the configuration for this VM. */
-  public VmConfig config() {
-    return config;
-  }
-
-  /** Returns the name of this VM. */
-  public final String name() {
-    return config.name();
-  }
-
   /** Returns the type of this VM. */
   public abstract VmType type();
 
+  /** Returns the configuration for this VM. */
+  public abstract VmConfig config();
+
+  /** Returns the classpath that should be used for workers on this VM. */
+  public abstract String classpath();
+
+  /** Returns the name of this VM. */
+  public final String name() {
+    return config().name();
+  }
+
   /** Returns the (optional) configured home directory path for this VM. */
   public final Optional<String> home() {
-    return config.home();
+    return config().home();
   }
 
   /** Returns the name of or relative path to the VM executable file. */
@@ -65,7 +56,7 @@ public abstract class Vm {
    */
   public final ImmutableList<String> args(Iterable<String>... additionalArgs) {
     ImmutableList.Builder<String> builder = ImmutableList.builder();
-    builder.addAll(config.args());
+    builder.addAll(config().args());
     for (Iterable<String> args : additionalArgs) {
       builder.addAll(args);
     }
@@ -83,11 +74,6 @@ public abstract class Vm {
   // TODO(cgdecker): Should this go in TrialSpec?
   // But in TrialSpec it would need to be in the form "if VM is JVM ... else ...", which isn't great
   public abstract ImmutableSet<String> trialArgs();
-
-  /** Returns the classpath that should be used for workers on this VM. */
-  public final String classpath() {
-    return classpath;
-  }
 
   /** Returns the VM arguments to use for specifying the given classpath for the VM. */
   // NOTE: This mainly just exists because app_process is weird; all other supported VM executables
@@ -107,4 +93,9 @@ public abstract class Vm {
    * VmSpec} for a run.
    */
   public abstract Predicate<String> vmPropertiesToRetain();
+
+  @Override
+  public final String toString() {
+    return name();
+  }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfo.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.worker.targetinfo;
+
+import com.google.auto.value.AutoValue;
+import com.google.caliper.core.BenchmarkClassModel;
+import com.google.caliper.model.Host;
+import com.google.caliper.runner.target.Target;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+/**
+ * Information about the targets for the run. Specifically, the single, identical model of the
+ * benchmark class that each of them should have produced, as well as a mapping from each target to
+ * the {@link Host} properties for that target's device.
+ */
+@AutoValue
+public abstract class TargetInfo {
+
+  static TargetInfo create(BenchmarkClassModel model, Map<Target, Host> hosts) {
+    return new AutoValue_TargetInfo(model, ImmutableMap.copyOf(hosts));
+  }
+
+  /**
+   * Returns the benchmark class model. Each of the targets for the run must have produced an
+   * identical model of the class to all of the other targets or we would have failed to get this
+   * target info.
+   */
+  public abstract BenchmarkClassModel benchmarkClassModel();
+
+  /** Returns the mapping of target to host device properties. */
+  public abstract ImmutableMap<Target, Host> hosts();
+}

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoComponent.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoComponent.java
@@ -14,22 +14,20 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner.worker.benchmarkmodel;
+package com.google.caliper.runner.worker.targetinfo;
 
-import com.google.caliper.core.BenchmarkClassModel;
+import com.google.caliper.bridge.TargetInfoLogMessage;
 import com.google.caliper.runner.target.Target;
 import com.google.caliper.runner.worker.WorkerRunner;
 import com.google.caliper.runner.worker.WorkerScoped;
 import dagger.BindsInstance;
 import dagger.Subcomponent;
 
-/**
- * Component for creating a {@link WorkerRunner} for getting the class model from a specific target.
- */
+/** Component for creating a {@link WorkerRunner} for getting the info from a specific target. */
 @WorkerScoped
-@Subcomponent(modules = BenchmarkModelModule.class)
-public interface BenchmarkModelComponent {
-  WorkerRunner<BenchmarkClassModel> workerRunner();
+@Subcomponent(modules = TargetInfoModule.class)
+public interface TargetInfoComponent {
+  WorkerRunner<TargetInfoLogMessage> workerRunner();
 
   /** Builder for the component. */
   @Subcomponent.Builder
@@ -39,6 +37,6 @@ public interface BenchmarkModelComponent {
     Builder target(Target target);
 
     /** Builds a new component. */
-    BenchmarkModelComponent build();
+    TargetInfoComponent build();
   }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoFactory.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoFactory.java
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner.worker.benchmarkmodel;
-
-import com.google.caliper.core.BenchmarkClassModel;
+package com.google.caliper.runner.worker.targetinfo;
 
 /**
- * Factory for creating model of the benchmark class for the rest of the runner to use.
+ * Factory for getting information, including a model of the benchmark class, from the run's targets
+ * for the rest of the run to use.
  *
  * @author Colin Decker
  */
-public interface BenchmarkModelFactory {
+public interface TargetInfoFactory {
 
-  /**
-   * Creates a new {@link BenchmarkClassModel} of the benchmark class.
-   */
-  BenchmarkClassModel createBenchmarkClassModel();
+  /** Gets information on the targets for this benchmark run. */
+  TargetInfo getTargetInfo();
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoModule.java
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner.worker.benchmarkmodel;
+package com.google.caliper.runner.worker.targetinfo;
 
-import com.google.caliper.core.BenchmarkClassModel;
+import com.google.caliper.bridge.TargetInfoLogMessage;
 import com.google.caliper.runner.worker.WorkerModule;
 import com.google.caliper.runner.worker.WorkerProcessor;
 import com.google.caliper.runner.worker.WorkerSpec;
 import dagger.Binds;
 import dagger.Module;
 
-/** Module with bindings needed for getting a benchmark model from a worker. */
+/** Module with bindings needed for getting target info from a worker. */
 @Module(includes = WorkerModule.class)
-abstract class BenchmarkModelModule {
-  private BenchmarkModelModule() {}
+abstract class TargetInfoModule {
+  private TargetInfoModule() {}
 
   @Binds
-  abstract WorkerProcessor<BenchmarkClassModel> bindWorkerProcessor(
-      BenchmarkModelWorkerProcessor processor);
+  abstract WorkerProcessor<TargetInfoLogMessage> bindWorkerProcessor(TargetInfoProcessor processor);
 
   @Binds
-  abstract WorkerSpec bindWorkerSpec(BenchmarkModelWorkerSpec spec);
+  abstract WorkerSpec bindWorkerSpec(TargetInfoSpec spec);
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoProcessor.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoProcessor.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner.worker.benchmarkmodel;
+package com.google.caliper.runner.worker.targetinfo;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.google.caliper.bridge.AbstractLogMessageVisitor;
-import com.google.caliper.bridge.BenchmarkModelLogMessage;
 import com.google.caliper.bridge.LogMessage;
 import com.google.caliper.bridge.LogMessageVisitor;
-import com.google.caliper.core.BenchmarkClassModel;
+import com.google.caliper.bridge.TargetInfoLogMessage;
 import com.google.caliper.runner.worker.FailureLogMessageVisitor;
 import com.google.caliper.runner.worker.Worker;
 import com.google.caliper.runner.worker.WorkerProcessor;
@@ -30,21 +29,21 @@ import com.google.caliper.util.ShortDuration;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
-/** {@link WorkerProcessor} for receiving a {@link BenchmarkClassModel} from the worker. */
-final class BenchmarkModelWorkerProcessor extends WorkerProcessor<BenchmarkClassModel> {
+/** {@link WorkerProcessor} for receiving a target info from the worker. */
+final class TargetInfoProcessor extends WorkerProcessor<TargetInfoLogMessage> {
 
-  @Nullable private volatile BenchmarkClassModel result = null;
+  @Nullable private volatile TargetInfoLogMessage result = null;
 
   private final LogMessageVisitor successVisitor =
       new AbstractLogMessageVisitor() {
         @Override
-        public void visit(BenchmarkModelLogMessage logMessage) {
-          BenchmarkModelWorkerProcessor.this.result = logMessage.model();
+        public void visit(TargetInfoLogMessage logMessage) {
+          TargetInfoProcessor.this.result = logMessage;
         }
       };
 
   @Inject
-  BenchmarkModelWorkerProcessor() {}
+  TargetInfoProcessor() {}
 
   @Override
   public ShortDuration timeLimit() {
@@ -60,7 +59,7 @@ final class BenchmarkModelWorkerProcessor extends WorkerProcessor<BenchmarkClass
   }
 
   @Override
-  public BenchmarkClassModel getResult() {
+  public TargetInfoLogMessage getResult() {
     return result;
   }
 }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoSpec.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/targetinfo/TargetInfoSpec.java
@@ -14,29 +14,28 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner.worker.benchmarkmodel;
+package com.google.caliper.runner.worker.targetinfo;
 
-import com.google.caliper.bridge.BenchmarkModelRequest;
+import com.google.caliper.bridge.TargetInfoRequest;
 import com.google.caliper.bridge.WorkerRequest;
 import com.google.caliper.runner.options.CaliperOptions;
 import com.google.caliper.runner.server.LocalPort;
 import com.google.caliper.runner.target.Target;
 import com.google.caliper.runner.worker.WorkerScoped;
 import com.google.caliper.runner.worker.WorkerSpec;
-import com.google.common.collect.ImmutableList;
 import java.io.PrintWriter;
 import java.util.UUID;
 import javax.inject.Inject;
 
-/** A {@link WorkerSpec} for getting a benchmark class model from a target. */
+/** A {@link WorkerSpec} for getting target info from a target. */
 @WorkerScoped
-final class BenchmarkModelWorkerSpec extends WorkerSpec {
+final class TargetInfoSpec extends WorkerSpec {
 
   private final Target target;
   private final CaliperOptions options;
 
   @Inject
-  BenchmarkModelWorkerSpec(Target target, UUID id, @LocalPort int port, CaliperOptions options) {
+  TargetInfoSpec(Target target, UUID id, @LocalPort int port, CaliperOptions options) {
     super(target, id, id, port, options.benchmarkClassName());
     this.target = target;
     this.options = options;
@@ -44,19 +43,12 @@ final class BenchmarkModelWorkerSpec extends WorkerSpec {
 
   @Override
   public String name() {
-    return "benchmark-model-" + target.name();
+    return "target-info-" + target.name();
   }
 
   @Override
   public WorkerRequest request() {
-    return BenchmarkModelRequest.create(options.benchmarkClassName(), options.userParameters());
-  }
-
-  @Override
-  public ImmutableList<String> additionalVmOptions() {
-    // Use a relatively low heap size since nothing the worker does should require much memory.
-    // These go after the default options, so they'll override them.
-    return ImmutableList.of("-Xms32m", "-Xmx512m");
+    return TargetInfoRequest.create(options.userParameters());
   }
 
   @Override

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialModule.java
@@ -30,6 +30,7 @@ import com.google.caliper.runner.worker.WorkerProcessor;
 import com.google.caliper.runner.worker.WorkerRunner;
 import com.google.caliper.runner.worker.WorkerScoped;
 import com.google.caliper.runner.worker.WorkerSpec;
+import com.google.common.collect.ImmutableMap;
 import dagger.Binds;
 import dagger.Provides;
 import dagger.producers.ProducerModule;
@@ -67,6 +68,11 @@ abstract class TrialModule {
   @Provides
   static MeasurementCollectingVisitor provideMeasurementCollectingVisitor(Experiment experiment) {
     return experiment.instrumentedMethod().getMeasurementCollectingVisitor();
+  }
+
+  @Provides
+  static Host provideHost(Target target, ImmutableMap<Target, Host> hostsByTarget) {
+    return hostsByTarget.get(target);
   }
 
   @Provides

--- a/caliper-runner/src/test/java/com/google/caliper/runner/options/ParsedOptionsTest.java
+++ b/caliper-runner/src/test/java/com/google/caliper/runner/options/ParsedOptionsTest.java
@@ -14,6 +14,7 @@
 
 package com.google.caliper.runner.options;
 
+import static com.google.common.truth.Truth.assertThat;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -116,6 +117,60 @@ public class ParsedOptionsTest {
 
     assertNull(options.benchmarkClassName());
     checkDefaults(options);
+  }
+
+  @Test
+  public void testWorkerClasspaths() {
+    CaliperOptions options = ParsedOptions.from(new String[] {
+        "--worker-classpath-jvm=jvmclasspath",
+        "--worker-classpath-android=androidclasspath"},
+        false);
+    assertThat(options.workerClasspath("jvm")).hasValue("jvmclasspath");
+    assertThat(options.workerClasspath("android")).hasValue("androidclasspath");
+  }
+
+  @Test
+  public void testWorkerClasspaths_justOne() {
+    CaliperOptions options = ParsedOptions.from(new String[] {
+            "--worker-classpath-jvm=classpath"},
+        false);
+    assertThat(options.workerClasspath("jvm")).hasValue("classpath");
+    assertThat(options.workerClasspath("android")).isAbsent();
+  }
+
+  @Test
+  public void testWorkerClasspaths_default() {
+    CaliperOptions options = ParsedOptions.from(new String[] {
+            "--worker-classpath=classpath"},
+        false);
+    assertThat(options.workerClasspath("jvm")).hasValue("classpath");
+    assertThat(options.workerClasspath("android")).hasValue("classpath");
+  }
+
+  @Test
+  public void testWorkerClasspaths_invalidArgs() {
+    CaliperOptions options = ParsedOptions.from(new String[] {
+            "--worker-classpath=classpath"},
+        false);
+    try {
+      options.workerClasspath("foo");
+      fail();
+    } catch (IllegalArgumentException expected) {}
+
+    try {
+      options.workerClasspath("");
+      fail();
+    } catch (IllegalArgumentException expected) {}
+  }
+
+  @Test
+  public void testWorkerClasspaths_bothDefaultAndSpecificIllegal() {
+    try {
+      ParsedOptions.from(
+          new String[] {"--worker-classpath=classpath", "--worker-classpath-jvm=classpath"}, false);
+      fail();
+    } catch (InvalidCommandException expected) {
+    }
   }
 
   private void checkDefaults(CaliperOptions options) {

--- a/caliper-runner/src/test/java/com/google/caliper/runner/options/ParsedOptionsTest.java
+++ b/caliper-runner/src/test/java/com/google/caliper/runner/options/ParsedOptionsTest.java
@@ -104,6 +104,26 @@ public class ParsedOptionsTest {
   }
 
   @Test
+  public void testVmNames_doNotAllowAt() {
+    try {
+      ParsedOptions.from(new String[] {"-m", "foo@bar"}, false);
+      fail();
+    } catch (InvalidCommandException expected) {
+      assertThat(expected).hasMessageThat().contains("'@'");
+    }
+  }
+
+  @Test
+  public void testDeviceName_doNotAllowAt() {
+    try {
+      ParsedOptions.from(new String[] {"-e", "foo@bar"}, false);
+      fail();
+    } catch (InvalidCommandException expected) {
+      assertThat(expected).hasMessageThat().contains("'@'");
+    }
+  }
+
+  @Test
   public void testDefaults_RequireBenchmarkClassName() throws InvalidCommandException {
     CaliperOptions options = ParsedOptions.from(new String[] {CLASS_NAME}, true);
 

--- a/caliper-worker/src/main/java/com/google/caliper/worker/handler/HostDevice.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/handler/HostDevice.java
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package com.google.caliper.runner;
+package com.google.caliper.worker.handler;
 
-import com.google.caliper.model.Host;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
-import dagger.Module;
-import dagger.Provides;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -33,20 +30,14 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Module that creates and binds a {@link Host} object that describes the host environment: JVM
- * version, OS details, etc.
+ * Handles getting a map of device properties to send back to the runner for use as the {@code Host}
+ * model data for the run.
  */
-@Module
-abstract class HostModule {
-  private HostModule() {}
+abstract class HostDevice {
+  private HostDevice() {}
 
-  @Provides
-  @RunScoped
-  static Host provideHost() {
-    return new Host.Builder().addAllProperies(getProperties()).build();
-  }
-
-  private static Map<String, String> getProperties() {
+  /** Gets a selection of properties about the device this worker is running on. */
+  static Map<String, String> getProperties() {
     TreeMap<String, String> propertyMap = Maps.newTreeMap();
 
     Map<String, String> sysProps = Maps.fromProperties(System.getProperties());

--- a/caliper-worker/src/main/java/com/google/caliper/worker/handler/RequestHandlerModule.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/handler/RequestHandlerModule.java
@@ -16,8 +16,8 @@
 
 package com.google.caliper.worker.handler;
 
-import com.google.caliper.bridge.BenchmarkModelRequest;
 import com.google.caliper.bridge.DryRunRequest;
+import com.google.caliper.bridge.TargetInfoRequest;
 import com.google.caliper.bridge.TrialRequest;
 import dagger.Binds;
 import dagger.Module;
@@ -35,8 +35,8 @@ public abstract class RequestHandlerModule {
 
   @Binds
   @IntoMap
-  @RequestTypeKey(BenchmarkModelRequest.class)
-  abstract RequestHandler bindModelHandler(BenchmarkModelHandler handler);
+  @RequestTypeKey(TargetInfoRequest.class)
+  abstract RequestHandler bindTargetInfoHandler(TargetInfoHandler handler);
 
   @Binds
   @IntoMap

--- a/caliper-worker/src/main/java/com/google/caliper/worker/handler/TargetInfoHandler.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/handler/TargetInfoHandler.java
@@ -16,8 +16,8 @@
 
 package com.google.caliper.worker.handler;
 
-import com.google.caliper.bridge.BenchmarkModelLogMessage;
-import com.google.caliper.bridge.BenchmarkModelRequest;
+import com.google.caliper.bridge.TargetInfoLogMessage;
+import com.google.caliper.bridge.TargetInfoRequest;
 import com.google.caliper.bridge.WorkerRequest;
 import com.google.caliper.core.BenchmarkClassModel;
 import com.google.caliper.core.Running.BenchmarkClass;
@@ -26,17 +26,17 @@ import java.io.IOException;
 import javax.inject.Inject;
 
 /**
- * Handler for a {@link BenchmarkModelRequest}.
+ * Handler for a {@link TargetInfoRequest}.
  *
  * @author Colin Decker
  */
-final class BenchmarkModelHandler implements RequestHandler {
+final class TargetInfoHandler implements RequestHandler {
 
   private final ClientConnectionService clientConnection;
   private final Class<?> benchmarkClass;
 
   @Inject
-  BenchmarkModelHandler(
+  TargetInfoHandler(
       ClientConnectionService clientConnection, @BenchmarkClass Class<?> benchmarkClass) {
     this.clientConnection = clientConnection;
     this.benchmarkClass = benchmarkClass;
@@ -44,9 +44,9 @@ final class BenchmarkModelHandler implements RequestHandler {
 
   @Override
   public void handleRequest(WorkerRequest request) throws IOException {
-    BenchmarkModelRequest modelRequest = (BenchmarkModelRequest) request;
+    TargetInfoRequest targetInfoRequest = (TargetInfoRequest) request;
     BenchmarkClassModel model = BenchmarkClassModel.create(benchmarkClass);
-    BenchmarkClassModel.validateUserParameters(benchmarkClass, modelRequest.userParameters());
-    clientConnection.send(BenchmarkModelLogMessage.create(model));
+    BenchmarkClassModel.validateUserParameters(benchmarkClass, targetInfoRequest.userParameters());
+    clientConnection.send(TargetInfoLogMessage.create(model, HostDevice.getProperties()));
   }
 }

--- a/caliper/src/test/java/com/google/caliper/runner/target/LocalDeviceTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/target/LocalDeviceTest.java
@@ -145,7 +145,7 @@ public class LocalDeviceTest {
             .type(VmType.JVM)
             .home(System.getProperty("java.home"))
             .build();
-    Vm vm = new Jvm(config, "classpath");
+    Vm vm = Jvm.create(config, "classpath");
     String path = device.vmExecutablePath(vm);
     File javaExecutable = new File(path);
     assertTrue("Could not find: " + javaExecutable, javaExecutable.exists());


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Get Host info from workers at the same time as the BenchmarkClassModel. Rename the "benchmark model" worker stuff to "target info" since it no longer just gets a benchmark model.

8ed1b23fb76358dfdf21b699b0b2ef04a322c6ed

-------

<p> Add the ability to provide worker classpaths on the command line.

bcb07156f1155bdb0a5698a62caeb777b617ed3a

-------

<p> Add missing config property to fix android benchmarks.

64b861258aef6b736a338f92f91faed4b12a56f5

-------

<p> Future-proof device and VM names. Don't allow them to contain '@', so that if we want to allow VMs on multiple devices in a single run in the future, we'll be able to change it so that users can specify VMs in the form <vmname>@<devicename>.

155103327fa68e1191b0bcf60ea58401d692ce9d