### PR TITLE
Moe Sync

### DIFF
--- a/caliper-core/src/main/java/com/google/caliper/bridge/RemoteClasspathMessage.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/RemoteClasspathMessage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.bridge;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+
+/** Message sent by a remote device to provide the local worker classpath on that device. */
+@AutoValue
+public abstract class RemoteClasspathMessage implements Serializable {
+
+  RemoteClasspathMessage() {}
+
+  // Note that if Caliper were at some point to use a runner proxy for something other than running
+  // on Android devices, this message might need to instead be able to return a map of VM type to
+  // the remote classpath for that VM type... but for now it just needs one classpath.
+
+  /** Creates a new {@link RemoteClasspathMessage}. */
+  public static RemoteClasspathMessage create(String classpath) {
+    return new AutoValue_RemoteClasspathMessage(classpath);
+  }
+
+  /** Returns the classpath. */
+  public abstract String classpath();
+}

--- a/caliper-core/src/main/java/com/google/caliper/bridge/StopProxyRequest.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/StopProxyRequest.java
@@ -16,24 +16,7 @@
 
 package com.google.caliper.bridge;
 
-import com.google.auto.value.AutoValue;
 import java.io.Serializable;
-import java.util.UUID;
 
-/** A message sent from a device to the runner to tell it that a VM stopped. */
-@AutoValue
-public abstract class VmStoppedMessage implements Serializable {
-
-  VmStoppedMessage() {}
-
-  /** Creates a new {@link VmStoppedMessage}. */
-  public static VmStoppedMessage create(UUID vmId, int exitCode) {
-    return new AutoValue_VmStoppedMessage(vmId, exitCode);
-  }
-
-  /** Returns the UUID identifying the VM that stopped. */
-  public abstract UUID vmId();
-
-  /** Returns the exit code of the process. */
-  public abstract int exitCode();
-}
+/** Request to send to a runner proxy on a remote device to tell it to stop. */
+public final class StopProxyRequest implements Serializable {}

--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfig.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfig.java
@@ -103,15 +103,21 @@ public final class CaliperConfig {
     ImmutableMap<String, String> devices = subgroupMap(properties, "device");
     ImmutableMap<String, String> device = subgroupMap(devices, deviceName);
 
-    String deviceType = device.get("type");
-    if (deviceType == null) {
+    String deviceTypeField = device.get("type");
+    if (deviceTypeField == null) {
       throw new InvalidConfigurationException(
           "Missing configuration field: device." + deviceName + ".type");
     }
 
+    DeviceType deviceType = DeviceType.of(deviceTypeField);
+    if (deviceType.equals(DeviceType.ADB)) {
+      // Ok, technically nothing wrong with the configuration, but this is super-temporary anyway
+      throw new InvalidConfigurationException("adb devices are not supported yet");
+    }
+
     return DeviceConfig.builder()
         .name(deviceName)
-        .type(DeviceType.of(deviceType))
+        .type(deviceType)
         .options(subgroupMap(device, "options"))
         .build();
   }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/DeviceType.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/DeviceType.java
@@ -21,13 +21,18 @@ import com.google.common.base.Joiner;
 /** Enumeration of types of devices supported by Caliper. */
 public enum DeviceType {
   /** The device on which Caliper itself is running. */
-  LOCAL;
+  LOCAL,
+
+  /** An Android device/emulator connected via ADB. */
+  ADB;
 
   /** Gets the {@link DeviceType} for the given {@code type} field string. */
   public static DeviceType of(String type) {
     switch (type) {
       case "local":
         return LOCAL;
+      case "adb":
+        return ADB;
       default:
         throw new InvalidConfigurationException(
             String.format(

--- a/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerSocketService.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerSocketService.java
@@ -30,15 +30,12 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.SettableFuture;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
-import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -189,17 +186,7 @@ public final class ServerSocketService extends AbstractExecutionThreadService {
   }
 
   private UUID getId(Socket socket) throws IOException {
-    ReadableByteChannel channel = Channels.newChannel(socket.getInputStream());
-
-    ByteBuffer uuidBuf = ByteBuffer.allocate(Uuids.UUID_BYTES);
-    while (uuidBuf.hasRemaining()) {
-      if (channel.read(uuidBuf) == -1) {
-        throw new EOFException("unexpected EOF while reading socket connection ID");
-      }
-    }
-
-    uuidBuf.flip();
-    return Uuids.fromBytes(uuidBuf);
+    return Uuids.readFromChannel(Channels.newChannel(socket.getInputStream()));
   }
 
   /**

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/AdbDevice.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/AdbDevice.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.target;
+
+import static com.google.caliper.runner.config.VmType.ANDROID;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.StandardSystemProperty.PATH_SEPARATOR;
+import static com.google.common.base.Strings.nullToEmpty;
+
+import com.google.caliper.bridge.StartVmRequest;
+import com.google.caliper.runner.config.DeviceConfig;
+import com.google.caliper.runner.config.InvalidConfigurationException;
+import com.google.caliper.runner.config.VmConfig;
+import com.google.caliper.runner.config.VmType;
+import com.google.caliper.runner.options.CaliperOptions;
+import com.google.caliper.runner.server.LocalPort;
+import com.google.caliper.runner.target.Shell.Result;
+import com.google.caliper.runner.target.VmProcess.Logger;
+import com.google.caliper.util.InvalidCommandException;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+
+/**
+ * An ADB-connected Android device or emulator.
+ *
+ * @author Colin Decker
+ */
+final class AdbDevice extends Device {
+
+  /** L; required for adb reverse. */
+  private static final int MIN_API_LEVEL = 21;
+
+  private static final CharMatcher DIGITS = CharMatcher.inRange('0', '9');
+  private static final Splitter CLASSPATH_SPLITTER = Splitter.on(PATH_SEPARATOR.value());
+
+  private static final String CALIPER_PACKAGE_NAME = "com.google.caliper";
+
+  private final CaliperOptions caliperOptions;
+
+  private Shell shell;
+  private final String adb = "adb"; // TODO(cgdecker): Make this configurable?
+
+  private final int port;
+  private final ProxyConnectionService proxyConnection;
+  private String remoteClasspath;
+
+  @Inject
+  AdbDevice(
+      DeviceConfig config,
+      ShutdownHookRegistrar shutdownHookRegistrar,
+      CaliperOptions caliperOptions,
+      Shell shell,
+      ProxyConnectionService proxyConnection,
+      @LocalPort int port) {
+    super(config, shutdownHookRegistrar);
+    this.caliperOptions = caliperOptions;
+    this.shell = shell;
+    this.proxyConnection = proxyConnection;
+    this.port = port;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    shell.execute(adb, "start-server").orThrow();
+
+    String selector = nullToEmpty(config().options().get("selector"));
+
+    // selector string may consist of multiple arguments or be an empty string, so write this
+    // command as a single string to let shell handle splitting it
+    String deviceSerialNumber = shell.execute(adb + " " + selector + " get-serialno")
+        .orThrow()
+        .stdout();
+
+    selectDevice(deviceSerialNumber);
+    setReversePortForwarding();
+
+    install(getWorkerApk());
+    startActivity(
+        "com.google.caliper/.worker.CaliperProxyActivity",
+        ImmutableMap.of(
+            "com.google.caliper.runner_port", "" + port,
+            "com.google.caliper.proxy_id", proxyConnection.proxyId().toString()));
+
+    proxyConnection.startAsync().awaitRunning();
+    this.remoteClasspath = proxyConnection.getRemoteClasspath();
+  }
+
+  private void selectDevice(String serialNumber) {
+    shell = shell.withEnv(ImmutableMap.of("ANDROID_SERIAL", serialNumber));
+    checkDeviceApiLevel();
+  }
+
+  private void checkDeviceApiLevel() {
+    String out = shell.execute(adb + " shell getprop ro.build.version.sdk").orThrow().stdout();
+    if (!DIGITS.matchesAllOf(out)) {
+      throw new ShellException(
+          "unexpected output from command 'adb shell getprop ro.build.version.sdk': " + out);
+    }
+    int apiLevel = Integer.parseInt(out);
+
+    if (apiLevel < MIN_API_LEVEL) {
+      throw new InvalidConfigurationException(
+          String.format(
+              "device API level %s is not supported; Caliper only supports API level %s+",
+              apiLevel, MIN_API_LEVEL));
+    }
+  }
+
+  /**
+   * Sets up reverse port forwarding to allow the device to connect to the given port on this
+   * computer.
+   */
+  private void setReversePortForwarding() {
+    String tcpPort = "tcp:" + port;
+    shell.execute(adb, "reverse", tcpPort, tcpPort).orThrow();
+  }
+
+  /** Removes the reverse port forwarding for the given port. */
+  private void removeReversePortForwarding() {
+    String tcpPort = "tcp:" + port;
+    shell.execute(adb, "reverse", "--remove", tcpPort).orThrow();
+  }
+
+  /** Installs the given apk file to the device. */
+  private void install(File apk) {
+    shell.execute(adb, "install", "-r", apk.getAbsolutePath()).orThrow();
+  }
+
+  /** Uninstalls the package with the given name from the device. */
+  private void uninstall(String packageName) {
+    shell.execute(adb, "uninstall", packageName);
+  }
+
+  /**
+   * Starts the activity with the given intent, adding the given extras to the parameters for the
+   * activity.
+   */
+  private void startActivity(String intent, Map<String, String> extras) {
+    ImmutableList.Builder<String> builder =
+        ImmutableList.<String>builder()
+            .add(adb)
+            .add("shell")
+            .add("am", "start")
+            .add("-n", intent)
+            .add("-a", "android.intent.action.MAIN")
+            .add("-c", "android.intent.category.LAUNCHER");
+    for (Map.Entry<String, String> entry : extras.entrySet()) {
+      builder.add("-e", entry.getKey(), entry.getValue());
+    }
+    shell.execute(builder.build()).orThrow("failed to start activity");
+  }
+
+  private File getWorkerApk() {
+    Optional<String> optionalClasspath = caliperOptions.workerClasspath(ANDROID.toString());
+    if (!optionalClasspath.isPresent()) {
+      throw new InvalidCommandException("No worker classpath for VM type %s provided", ANDROID);
+    }
+    List<String> classpath = CLASSPATH_SPLITTER.splitToList(optionalClasspath.get());
+
+    if (classpath.size() != 1 || !classpath.get(0).endsWith(".apk")) {
+      throw new InvalidCommandException(
+          "Android worker classpath must consist of a single file with extension .apk");
+    }
+
+    File apk = new File(classpath.get(0));
+    if (!apk.isFile()) {
+      throw new InvalidCommandException(
+          "Android worker apk '" + apk + "' does not exist or isn't a regular file");
+    }
+
+    return apk;
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    try {
+      proxyConnection.stopAsync();
+      uninstall(CALIPER_PACKAGE_NAME);
+    } finally {
+      removeReversePortForwarding();
+      proxyConnection.awaitTerminated();
+    }
+  }
+
+  @Override
+  public String vmExecutablePath(Vm vm) {
+    checkState(isRunning(), "AdbDevice service must be running to get VM executable path");
+    String executable = "/system/bin/" + vm.executable();
+    if (!fileExists(executable)) {
+      throw new VirtualMachineException(
+          "VM executable " + executable + " doesn't exist on device " + this);
+    }
+    return executable;
+  }
+
+  @Override
+  public String workerClasspath(VmType type) {
+    checkArgument(type.equals(ANDROID), "type must be ANDROID, not %s", type);
+    checkState(isRunning(), "AdbDevice service must be running to get worker classpath");
+    return remoteClasspath;
+  }
+
+  @Override
+  public VmType defaultVmType() {
+    return ANDROID;
+  }
+
+  @Override
+  public VmConfig defaultVmConfig() {
+    return VmConfig.builder().name("default").type(ANDROID).executable("dalvikvm").build();
+  }
+
+  @Override
+  protected VmProcess doStartVm(VmProcess.Spec spec, Logger logger) throws Exception {
+    StartVmRequest request = StartVmRequest.create(spec.id(), createCommand(spec));
+    return proxyConnection.startVm(request);
+  }
+
+  private boolean fileExists(String path) {
+    Result result = shell.execute(adb, "shell", "[", "-f", path, "]");
+    if (!result.isSuccessful() && !result.stderr().isEmpty()) {
+      // only throw if there was output to stderr in addition to not being successful; a non-zero
+      // exit code is expected if the command "succeeds" but the file didn't exist
+      result.orThrow();
+      throw new AssertionError(); // unreachable
+    }
+    return result.isSuccessful();
+  }
+
+  private static ImmutableList<String> createCommand(VmProcess.Spec spec) {
+    return new ImmutableList.Builder<String>()
+        .add(spec.target().vmExecutablePath())
+        .addAll(spec.vmOptions())
+        .add(spec.mainClass())
+        .addAll(spec.mainArgs())
+        .build();
+  }
+}

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/ProxyConnectionService.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/ProxyConnectionService.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.target;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.util.concurrent.Uninterruptibles.getUninterruptibly;
+
+import com.google.caliper.bridge.KillVmRequest;
+import com.google.caliper.bridge.OpenedSocket;
+import com.google.caliper.bridge.RemoteClasspathMessage;
+import com.google.caliper.bridge.StartVmRequest;
+import com.google.caliper.bridge.StopProxyRequest;
+import com.google.caliper.bridge.VmStoppedMessage;
+import com.google.caliper.runner.server.ServerSocketService;
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.SettableFuture;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.InterruptedException;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import javax.inject.Inject;
+
+/**
+ * Service for managing a connection to a proxy for the Caliper runner running on a remote device.
+ */
+final class ProxyConnectionService extends AbstractExecutionThreadService {
+
+  private final UUID proxyId = UUID.randomUUID();
+
+  private final ServerSocketService server;
+
+  private final Closer closer = Closer.create();
+  private OpenedSocket.Reader reader;
+  private OpenedSocket.Writer writer;
+
+  private final SettableFuture<String> classpathFuture = SettableFuture.create();
+  private final ConcurrentMap<UUID, VmProxy> vms = new ConcurrentHashMap<>();
+
+  @Inject
+  ProxyConnectionService(ServerSocketService server) {
+    this.server = server;
+  }
+
+  /** Returns the random UUID that identifies this proxy connection. */
+  public UUID proxyId() {
+    return proxyId;
+  }
+
+  @Override
+  public void startUp() throws IOException, ExecutionException, InterruptedException {
+    // Some other class should have handled starting the proxy process, so just wait for it to
+    // open its connection to us.
+    OpenedSocket socket = server.getConnection(proxyId).get();
+    this.reader = closer.register(socket.reader());
+    this.writer = closer.register(socket.writer());
+  }
+
+  @Override
+  public void run() throws IOException {
+    while (isRunning()) {
+      Object message = reader.read();
+      if (message == null) {
+        return;
+      }
+
+      if (message instanceof VmStoppedMessage) {
+        VmStoppedMessage stoppedMessage = (VmStoppedMessage) message;
+        UUID vmId = stoppedMessage.vmId();
+        VmProxy vm = vms.remove(vmId);
+        if (vm != null) {
+          vm.stopped(stoppedMessage.exitCode());
+        }
+      } else if (message instanceof RemoteClasspathMessage) {
+        classpathFuture.set(((RemoteClasspathMessage) message).classpath());
+      }
+    }
+  }
+
+  /** Returns the classpath to use for processes on the remote device. */
+  public String getRemoteClasspath() throws ExecutionException {
+    return getUninterruptibly(classpathFuture);
+  }
+
+  /**
+   * Starts a VM by sending the given request and return a {@link VmProcess} instance representing
+   * that VM.
+   */
+  public VmProcess startVm(StartVmRequest request) throws ExecutionException, IOException {
+    // Create the proxy for the VM first so that it's already in the map so there's no possibility
+    // of a race with the process exiting and sending a VmStoppedMessage back.
+    VmProxy vm = new VmProxy(request.vmId(), request.stdoutId(), request.stderrId());
+    vms.put(request.vmId(), vm);
+
+    // Send the request to actually start the VM.
+    writer.write(request);
+
+    vm.awaitStarted();
+    return vm;
+  }
+
+  @Override
+  public void shutDown() throws IOException {
+    try {
+      if (writer != null) {
+        writer.write(new StopProxyRequest());
+      }
+    } catch (Throwable e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /** Proxy for a VM process running on the remote device. */
+  private final class VmProxy extends VmProcess {
+    private final UUID vmId;
+    private final UUID stdoutId;
+    private final UUID stderrId;
+
+    private volatile InputStream stdout;
+    private volatile InputStream stderr;
+
+    private final SettableFuture<Integer> exitCode = SettableFuture.create();
+
+    VmProxy(UUID vmId, UUID stdoutId, UUID stderrId) {
+      this.vmId = checkNotNull(vmId);
+      this.stdoutId = checkNotNull(stdoutId);
+      this.stderrId = checkNotNull(stderrId);
+    }
+
+    /** Waits for the stdout/stderr connections to be established. */
+    void awaitStarted() throws ExecutionException {
+      this.stdout = getUninterruptibly(server.getInputStream(stdoutId));
+      this.stderr = getUninterruptibly(server.getInputStream(stderrId));
+    }
+
+    /** Sets the exit code of the process, unblocking {@code awaitExit()}. */
+    void stopped(int exitCode) {
+      this.exitCode.set(exitCode);
+    }
+
+    @Override
+    public InputStream stdout() {
+      return stdout;
+    }
+
+    @Override
+    public InputStream stderr() {
+      return stderr;
+    }
+
+    @Override
+    protected int doAwaitExit() throws InterruptedException {
+      try {
+        return exitCode.get();
+      } catch (ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    protected void doKill() {
+      try {
+        writer.write(KillVmRequest.create(vmId));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/Shell.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/Shell.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.target;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import javax.inject.Inject;
+
+/** Simple helper for running shell commands. */
+final class Shell {
+
+  private static final Joiner COMMAND_JOINER = Joiner.on(' ');
+  private static final Splitter COMMAND_SPLITTER = Splitter.on(' ');
+
+  private final ExecutorService executor;
+  private final ImmutableMap<String, String> env;
+
+  @Inject
+  Shell(ExecutorService executor) {
+    this(executor, ImmutableMap.of());
+  }
+
+  Shell(ExecutorService executor, Map<String, String> env) {
+    this.executor = checkNotNull(executor);
+    this.env = ImmutableMap.copyOf(env);
+  }
+
+  /** Returns a new shell that is equivalent to this one but with the given {@code env}. */
+  public Shell withEnv(Map<String, String> env) {
+    return new Shell(executor, env);
+  }
+
+  /** Executes the given {@code command}, splitting it into a series of arguments on spaces. */
+  public Result execute(String command) {
+    return execute(COMMAND_SPLITTER.splitToList(command));
+  }
+
+  /** Executes the command represented by the given series of arguments. */
+  public Result execute(String first, String second, String... rest) {
+    return execute(Lists.asList(first, second, rest));
+  }
+
+  /** Executes the given command. */
+  public Result execute(List<String> command) {
+    ProcessBuilder builder = new ProcessBuilder();
+    builder.environment().putAll(env);
+    builder.command(command);
+
+    try {
+      Process process = builder.start();
+      Future<String> stdoutFuture = inputStreamToString(process.getInputStream());
+      Future<String> stderrFuture = inputStreamToString(process.getErrorStream());
+      int exitCode = process.waitFor();
+      return new Result(command, exitCode, stdoutFuture.get(), stderrFuture.get());
+    } catch (Exception e) {
+      throw new ShellException(e);
+    }
+  }
+
+  private Future<String> inputStreamToString(final InputStream in) {
+    return executor.submit(
+        new Callable<String>() {
+          @Override
+          public String call() throws IOException {
+            // TODO(cgdecker): Figure out how to use the right charset for this.
+            // In the case of adb, the stdout/stderr in question here are from the adb process
+            // running on this (the runner) device. But of course there could be output from adb
+            // shell, which is output from shell commands run on the Android device. I don't know
+            // how adb deals with any discrepancy there in the first place. Beyond that, the default
+            // charset of the JVM we're running on could have been set to something different than
+            // than the default charset the adb command is using. I don't know how we can get a
+            // "correct" charset for either situation.
+            return CharStreams.toString(new InputStreamReader(in, Charset.defaultCharset()));
+          }
+        });
+  }
+
+  /** The result of executing a shell command. */
+  public static final class Result {
+    private final ImmutableList<String> command;
+    private final int exitCode;
+    private final String stdout;
+    private final String stderr;
+
+    Result(List<String> command, int exitCode, String stdout, String stderr) {
+      this.command = ImmutableList.copyOf(command);
+      this.exitCode = exitCode;
+      this.stdout = stdout.trim();
+      this.stderr = stderr.trim();
+    }
+
+    /** Returns the command that was executed. */
+    public ImmutableList<String> command() {
+      return command;
+    }
+
+    /** Returns whether or not the command was successful, based on its exit code. */
+    public boolean isSuccessful() {
+      return exitCode == 0;
+    }
+
+    /** Returns the exit code of the adb command. */
+    public int exitCode() {
+      return exitCode;
+    }
+
+    /** Returns the full stdout from the command. */
+    public String stdout() {
+      return stdout;
+    }
+
+    /** Returns the full stderr from the command. */
+    public String stderr() {
+      return stderr;
+    }
+
+    /**
+     * If this result is not successful, throws an exception using a default message giving the
+     * command that failed and including the stderr output. Otherwise, returns this result.
+     */
+    public Result orThrow() {
+      return orThrow("command failed: " + COMMAND_JOINER.join(command));
+    }
+
+    /**
+     * If this result is not successful, throws an exception using the given message (and including
+     * the stderr output). Otherwise, returns this result.
+     */
+    public Result orThrow(String message) {
+      if (!isSuccessful()) {
+        throw new ShellException(message, this);
+      }
+      return this;
+    }
+  }
+}

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/ShellException.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/ShellException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.target;
+
+/** Exception that may be thrown when a shell command fails. */
+class ShellException extends RuntimeException {
+  public ShellException(String message, Shell.Result result) {
+    this(message + "; stderr follows:\n" + result.stderr());
+  }
+
+  public ShellException(String message) {
+    super(message);
+  }
+
+  public ShellException(Throwable cause) {
+    super(cause);
+  }
+
+  public ShellException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/caliper-util/pom.xml
+++ b/caliper-util/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/AndroidClasspath.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/AndroidClasspath.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.worker;
+
+import android.content.pm.ApplicationInfo;
+import com.google.common.base.Joiner;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closer;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Utility for getting the classpath of the running process on Android in a form usable for
+ * launching new Android VMs using the same classpath. If the version of Android does not have
+ * native multidex support and the apk for the current application has multiple dexes, they may be
+ * extracted to a new location for use.
+ */
+final class AndroidClasspath {
+
+  /**
+   * Gets the classpath that Caliper should use when launching worker processes.
+   *
+   * <p>By default (apk with a single dex or when multidex is natively supported), the classpath is
+   * just the location of the apk containing this app. If the apk has multiple dexes and multidex
+   * isn't natively supported, all dexes are extracted from the apk and the classpath contains the
+   * path to each.
+   */
+  static String getClasspath(ApplicationInfo applicationInfo) throws IOException {
+    String apk = applicationInfo.sourceDir;
+
+    File codeCache = new File(applicationInfo.dataDir, "code_cache");
+
+    // If the secondary-dexes dir exists, that means that
+    // A) the apk is multidex, and
+    // B) there's no native multidex support on this Android version
+    File secondaryDexDir = new File(codeCache, "secondary-dexes");
+    if (!secondaryDexDir.exists()) {
+      return apk;
+    }
+
+    // Note: we don't use any dexes extracted to the secondary-dexes dir because they may have been
+    // modified (e.g. dexopt'ed) in place, which will cause DexOpt to fail when trying to start a
+    // worker process.
+    List<File> dexFiles = extractDexes(apk, new File(codeCache, "worker-dexes"));
+
+    return Joiner.on(System.getProperty("path.separator")).join(dexFiles);
+  }
+
+  /**
+   * Extracts {@code classes.dex} and all secondary {@code classes<N>.dex} files from the given apk
+   * file to the given target directory.
+   */
+  private static List<File> extractDexes(String apk, File targetDir) throws IOException {
+    targetDir.mkdirs();
+    List<File> results = new ArrayList<>();
+    Closer closer = Closer.create();
+    try {
+      ZipFile zip = closer.register(new CloseableZipFile(apk)).zipFile;
+
+      ZipEntry classesEntry = zip.getEntry("classes.dex");
+      if (classesEntry == null) {
+        throw new AssertionError("classes.dex not found in apk");
+      }
+
+      int i = 1;
+      do {
+        InputStream in = closer.register(zip.getInputStream(classesEntry));
+
+        File outFile = new File(targetDir, classesEntry.getName());
+        OutputStream out = closer.register(new FileOutputStream(outFile));
+
+        ByteStreams.copy(in, out);
+
+        results.add(outFile);
+
+        classesEntry = zip.getEntry("classes" + (++i) + ".dex");
+      } while (classesEntry != null);
+      return results;
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /**
+   * Workaround for the fact that {@code ZipFile} wasn't {@code Closeable} in earlier Java and
+   * Android versions, so that we can use it with {@link Closer}.
+   */
+  private static final class CloseableZipFile implements Closeable {
+    final ZipFile zipFile;
+
+    CloseableZipFile(String file) throws IOException {
+      this.zipFile = new ZipFile(file);
+    }
+
+    @Override
+    public void close() throws IOException {
+      zipFile.close();
+    }
+  }
+}

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxy.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxy.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.worker;
+
+import com.google.caliper.bridge.FailureLogMessage;
+import com.google.caliper.bridge.KillVmRequest;
+import com.google.caliper.bridge.RemoteClasspathMessage;
+import com.google.caliper.bridge.StartVmRequest;
+import com.google.caliper.bridge.StopProxyRequest;
+import com.google.caliper.bridge.VmStoppedMessage;
+import com.google.caliper.util.Uuids;
+import com.google.caliper.worker.connection.ClientConnectionService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Closer;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Service.Listener;
+import com.google.common.util.concurrent.Service.State;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.SocketChannel;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Proxy for the runner that handles starting up worker VMs for it and connecting those VMs back to
+ * the runner.
+ */
+@Singleton
+final class CaliperProxy extends AbstractExecutionThreadService {
+
+  private final InetSocketAddress clientAddress;
+  private final ClientConnectionService clientConnection;
+  private final ExecutorService executor;
+
+  /**
+   * The local classpath on this device that should be used for workers. See {@link
+   * RemoteClasspathMessage}.
+   */
+  private final String classpath;
+
+  /** Environment variables to add to the environment of VM processes we start. */
+  private final ImmutableMap<String, String> processEnv;
+
+  private final ConcurrentMap<UUID, ProcessHolder> processes = new ConcurrentHashMap<>();
+
+  @Inject
+  CaliperProxy(
+      InetSocketAddress clientAddress,
+      ClientConnectionService clientConnection,
+      ExecutorService executor,
+      String classpath,
+      ImmutableMap<String, String> processEnv) {
+    this.clientAddress = clientAddress;
+    this.clientConnection = clientConnection;
+    this.executor = executor;
+    this.classpath = classpath;
+    this.processEnv = processEnv;
+  }
+
+  @Override
+  public void startUp() throws Exception {
+    clientConnection.startAsync();
+    addListener(
+        new Listener() {
+          @Override
+          public void failed(State from, Throwable e) {
+            notifyError(e);
+          }
+        },
+        MoreExecutors.directExecutor());
+    clientConnection.awaitRunning();
+  }
+
+  @Override
+  public void run() throws Exception {
+    clientConnection.send(RemoteClasspathMessage.create(classpath));
+
+    while (isRunning()) {
+      final Object request = clientConnection.receive();
+      if (request instanceof StopProxyRequest) {
+        return;
+      }
+
+      if (request instanceof StartVmRequest) {
+        executor.execute(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  startVm((StartVmRequest) request);
+                } catch (Throwable e) {
+                  notifyError(e);
+                }
+              }
+            });
+      } else if (request instanceof KillVmRequest) {
+        executor.execute(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  killVm(((KillVmRequest) request).vmId());
+                } catch (Throwable e) {
+                  notifyError(e);
+                }
+              }
+            });
+      }
+    }
+  }
+
+  @Override
+  public void shutDown() throws Exception {
+    try {
+      for (UUID vmId : processes.keySet()) {
+        killVm(vmId);
+      }
+      for (ProcessHolder holder : processes.values()) {
+        holder.awaitCompletion();
+      }
+    } finally {
+      executor.shutdown();
+      clientConnection.stopAsync();
+    }
+  }
+
+  private void startVm(final StartVmRequest request) throws IOException {
+    ProcessBuilder builder = new ProcessBuilder().command(request.command());
+    builder.environment().putAll(processEnv);
+
+    Process process = builder.start();
+
+    UUID vmId = request.vmId();
+
+    // Need threads for each of these things since there's sadly no non-blocking way of doing them.
+    ImmutableList<Future<?>> futures =
+        ImmutableList.of(
+            pipeProcessInputStream(request.stdoutId(), process.getInputStream()),
+            pipeProcessInputStream(request.stderrId(), process.getErrorStream()),
+            awaitExit(vmId, process));
+
+    processes.put(vmId, new ProcessHolder(process, futures));
+  }
+
+  private void killVm(UUID vmId) {
+    ProcessHolder holder = processes.get(vmId);
+    if (holder != null) {
+      // Assuming the process is actually killed, this should lead to the thread waiting for the
+      // proccess to exit to see it exit and the things that need to happen when it exits should
+      // happen there.
+      holder.kill();
+    }
+  }
+
+  /**
+   * Opens a socket connection using the given ID and then copies the given {@code InputStream} to
+   * it, effectively piping the output from the process to the other end of the connection.
+   */
+  private Future<?> pipeProcessInputStream(UUID streamId, final InputStream in) {
+    return executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              Closer closer = Closer.create();
+              try {
+                SocketChannel channel = closer.register(SocketChannel.open(clientAddress));
+                Uuids.writeToChannel(streamId, channel);
+                ByteStreams.copy(Channels.newChannel(in), channel);
+              } catch (Throwable e) {
+                throw closer.rethrow(e);
+              } finally {
+                closer.close();
+              }
+            } catch (IOException e) {
+              notifyError(e);
+            }
+          }
+        });
+  }
+
+  private Future<?> awaitExit(final UUID vmId, final Process process) {
+    return executor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              int exitCode = waitForUninterruptibly(process);
+              if (clientConnection.isRunning()) {
+                processes.remove(vmId);
+                clientConnection.send(VmStoppedMessage.create(vmId, exitCode));
+              }
+            } catch (IOException e) {
+              notifyError(e);
+            }
+          }
+        });
+  }
+
+  private void notifyError(Throwable e) {
+    if (clientConnection.isRunning()) {
+      try {
+        clientConnection.send(FailureLogMessage.create(e));
+      } catch (IOException ignore) {
+      }
+    }
+  }
+
+  private static int waitForUninterruptibly(Process process) {
+    boolean interrupted = false;
+    try {
+      while (true) {
+        try {
+          return process.waitFor();
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
+      }
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  /** Holder for a process and futures representing threads associated with the process. */
+  private static class ProcessHolder {
+    private final Process process;
+    private final ImmutableList<Future<?>> futures;
+
+    ProcessHolder(Process process, ImmutableList<Future<?>> futures) {
+      this.process = process;
+      this.futures = futures;
+    }
+
+    void kill() {
+      process.destroy();
+    }
+
+    void awaitCompletion() {
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (Exception ignore) {
+        }
+      }
+    }
+  }
+}

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.worker;
+
+import static android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON;
+import static android.view.WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED;
+import static android.view.WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON;
+
+import android.app.Activity;
+import android.content.pm.ActivityInfo;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.Window;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.Service.Listener;
+import com.google.common.util.concurrent.Service.State;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+
+/**
+ * {@link Activity} that acts as a proxy the Caliper runner can use to manage worker processes.
+ *
+ * @author Colin Decker
+ */
+public final class CaliperProxyActivity extends Activity {
+
+  private static final String TAG = "CaliperProxy";
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    setTitle("Caliper Proxy");
+
+    // Prevent the app's orientation from changing, which would destroy this Activity and create a
+    // new one.
+    setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_NOSENSOR);
+    setPerformanceOptions();
+
+    UUID id = getProxyId();
+    try {
+      startProxy(id);
+    } catch (Throwable e) {
+      logErrorAndExit(id, "failed to start proxy service", e);
+    }
+  }
+
+  private void logErrorAndExit(UUID id, String message, Throwable e) {
+    Log.e(TAG, "<" + id + "> " + message, e);
+    System.exit(1);
+  }
+
+  /**
+   * Sets some options that attempt to make the performance consistent for the whole run.
+   *
+   * <p>As a baseline, turn the screen on and keep it on for the duration of the run in hopes that
+   * will keep the device from going into some low power mode.
+   *
+   * <p>On Android N and above, also call {@code setSustainedPerformanceMode}, which is intended to
+   * keep things like CPU clock consistent for the run. It only works for specific devices that
+   * implement it, though.
+   */
+  private void setPerformanceOptions() {
+    // This is just some basic stuff and I'm under no illusion that it is all that's needed to
+    // control for consistent performance.
+    Window window = getWindow();
+    window.addFlags(FLAG_SHOW_WHEN_LOCKED | FLAG_TURN_SCREEN_ON | FLAG_KEEP_SCREEN_ON);
+    if (VERSION.SDK_INT >= VERSION_CODES.N) {
+      window.setSustainedPerformanceMode(true);
+    }
+  }
+
+  /**
+   * Sets up and starts the Caliper proxy service, adding a listener to it that will exit this
+   * process when it exits.
+   */
+  private void startProxy(final UUID id) throws IOException {
+    // TODO(dpb): Maybe some of this could go in a Dagger module (but we probably don't want
+    // to be creating files as a side effect in @Provides methods)
+    InetSocketAddress runnerAddress =
+        new InetSocketAddress(InetAddress.getLoopbackAddress(), getRunnerPort());
+    String classpath = AndroidClasspath.getClasspath(getApplicationInfo());
+
+    String androidDataDir = System.getProperty("java.io.tmpdir") + "/data";
+    createWritableDalvikCache(androidDataDir);
+    ImmutableMap<String, String> processEnv = ImmutableMap.of("ANDROID_DATA", androidDataDir);
+
+    CaliperProxy proxy =
+        DaggerCaliperProxyComponent.builder()
+            .id(id)
+            .clientAddress(runnerAddress)
+            .classpath(classpath)
+            .processEnv(processEnv)
+            .build()
+            .caliperProxy();
+
+    proxy.addListener(
+        new Listener() {
+          @Override
+          public void failed(State from, Throwable e) {
+            logErrorAndExit(id, "proxy service failed", e);
+          }
+
+          @Override
+          public void terminated(State from) {
+            System.exit(0);
+          }
+        },
+        MoreExecutors.directExecutor());
+
+    proxy.startAsync();
+  }
+
+  private UUID getProxyId() {
+    String id = getIntent().getExtras().getString("com.google.caliper.proxy_id");
+    return UUID.fromString(id);
+  }
+
+  private int getRunnerPort() {
+    String port = getIntent().getExtras().getString("com.google.caliper.runner_port");
+    return Integer.parseInt(port);
+  }
+
+  private void createWritableDalvikCache(String androidDataDir) {
+    // The worker processes won't be able to write to the default location DexOpt wants to write
+    // optimized dexes to (/data/dalvik-cache), which will cause DexOpt (and the workers) to fail.
+    // To fix this, change the ANDROID_DATA env variable for the workers from /data to a location
+    // that's writable by the process.
+    // Note: the tmpdir for an app is specific to that app and not shared.
+    // Also create the dalvik-cache directory, since DexOpt will expect it to already exist.
+    File dalvikCache = new File(androidDataDir + "/dalvik-cache");
+    dalvikCache.mkdirs();
+  }
+}

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyComponent.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyComponent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.worker;
+
+import com.google.common.collect.ImmutableMap;
+import dagger.BindsInstance;
+import dagger.Component;
+import java.net.InetSocketAddress;
+import java.util.UUID;
+import javax.inject.Singleton;
+
+/** Component for creating a {@link CaliperProxy}. */
+@Singleton
+@Component(modules = CaliperProxyModule.class)
+interface CaliperProxyComponent {
+  /** Gets the {@link CaliperProxy} instance. */
+  CaliperProxy caliperProxy();
+
+  @Component.Builder
+  interface Builder {
+    @BindsInstance
+    Builder id(UUID id);
+
+    @BindsInstance
+    Builder classpath(String classpath);
+
+    @BindsInstance
+    Builder processEnv(ImmutableMap<String, String> processEnv);
+
+    @BindsInstance
+    Builder clientAddress(InetSocketAddress address);
+
+    CaliperProxyComponent build();
+  }
+}

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyModule.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyModule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.worker;
+
+import dagger.Module;
+import dagger.Provides;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.inject.Singleton;
+
+/** Modlue with bindings for creating a {@link CaliperProxy}. */
+@Module
+abstract class CaliperProxyModule {
+  private CaliperProxyModule() {}
+
+  @Provides
+  @Singleton
+  static ExecutorService executor() {
+    return Executors.newCachedThreadPool();
+  }
+}

--- a/caliper-worker/src/main/java/com/google/caliper/worker/connection/ClientConnectionService.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/connection/ClientConnectionService.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.AbstractIdleService;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.UUID;
 import javax.inject.Inject;
@@ -54,20 +53,12 @@ public final class ClientConnectionService extends AbstractIdleService {
 
   @Override
   protected void startUp() throws IOException {
-    channel = SocketChannel.open();
-    channel.connect(clientAddress);
-    sendId();
+    channel = SocketChannel.open(clientAddress);
+    Uuids.writeToChannel(id, channel);
 
     OpenedSocket openedSocket = OpenedSocket.fromSocket(channel);
     writer = openedSocket.writer();
     reader = openedSocket.reader();
-  }
-
-  private void sendId() throws IOException {
-    ByteBuffer buf = Uuids.toBytes(id);
-    while (buf.hasRemaining()) {
-      channel.write(buf);
-    }
   }
 
   @Override

--- a/caliper/src/main/resources/com/google/caliper/runner/config/default-config.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/default-config.properties
@@ -7,6 +7,12 @@
 # instrument.micro.options.reportedIntervals=7
 # instrument.micro.options.maxRuntime=10s
 
+# DEVICE CONFIG
+
+# To add an Android device with a specific serial number:
+# device.my-phone.type=adb
+# device.my-phone.options.selector=-s SERIALNUMBER
+
 # VM CONFIG
 vm.args=-Xmx3g -Xms3g
 

--- a/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
@@ -8,6 +8,15 @@
 device.local.type=local
 device.local.options.defaultVmType=jvm
 
+device.android.type=adb
+device.android.options.selector=
+
+device.android-device.type=adb
+device.android-device.options.selector=-d
+
+device.android-emulator.type=adb
+device.android-emulator.options.selector=-e
+
 ######################
 # VM CONFIGURATION
 ######################


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add truth to pom.xml for caliper-util now that it's used in tests there.

4890c36818a7a10bc9c2a6429fb698e450db53e6

-------

<p> Additional changes to proxy-related message classes in the bridge package.

60e6d7bec08aac83eaffd3a90afe9e03dc0e2a23

-------

<p> Start of AdbDevice implementation. The general way this is intended to work:

- User provides a worker classpath consisting of a single .apk containing their code as well as the Caliper worker code. Among the Caliper worker code will be CaliperProxyActivity.
- The AdbDevice starts up and uses adb (via shell commands) to install the apk to the device, set up reverse port forwarding (allow the device to connect directly to the port the runner listens on as if it were on the same machine) and start CaliperProxyActivity.
- CaliperProxyActivity opens a connection on the port back to the runner; AdbDevice recieves the connection.
- When asked to start a VM, AdbDevice sends a request over the socket connection to the proxy. The proxy starts the actual process, and opens two new socket connections to the runner. It pipes the process' stdout through one and stderr through the other. AdbDevice receives these connections and uses them to implement VmProcess.stdout() and .stderr().
- CaliperProxyActivity monitors each process it's started and notifies the runner when each completes. It can also receive and handle requests from the runner to kill specific processes it's started.

a571316ac33955a0c1246e88565a58f559fef85c

-------

<p> Add CaliperProxyActivity, an Android Activity that Caliper can run on a device to help it manage worker processes on that device. Most of the actual work of the proxy is done in CaliperProxy; the Activity is mostly responsible for creating and starting up the CaliperProxy service.

da18c941e08343d6e228d5b6a8bb886707dc6e96