### PR TITLE
Moe Sync

### DIFF
--- a/caliper-core/src/main/java/com/google/caliper/bridge/OpenedSocket.java
+++ b/caliper-core/src/main/java/com/google/caliper/bridge/OpenedSocket.java
@@ -78,7 +78,7 @@ public final class OpenedSocket {
     }
 
     /** Returns the next object, or {@code null} if we are at EOF. */
-    public Serializable read() throws IOException {
+    public synchronized Serializable read() throws IOException {
       try {
         return (Serializable) checkNotNull(input.readObject());
       } catch (EOFException eof) {
@@ -108,7 +108,7 @@ public final class OpenedSocket {
      * Writes the given objects and then flushes to ensure they're fully sent to the other side of
      * the connection.
      */
-    public void write(Serializable... objects) throws IOException {
+    public synchronized void write(Serializable... objects) throws IOException {
       for (Serializable object : objects) {
         output.writeObject(object);
       }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunnerModule.java
@@ -31,6 +31,7 @@ import com.google.caliper.runner.worker.WorkerOutputModule;
 import com.google.caliper.runner.worker.targetinfo.TargetInfoComponent;
 import com.google.caliper.runner.worker.targetinfo.TargetInfoFactory;
 import com.google.caliper.runner.worker.targetinfo.TargetInfoFromWorkerFactory;
+import com.google.caliper.runner.worker.trial.TrialExecutor;
 import com.google.caliper.util.OutputModule;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -38,6 +39,7 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.inject.Singleton;
 import org.joda.time.Instant;
@@ -81,7 +83,17 @@ abstract class CaliperRunnerModule {
 
   @Provides
   @Singleton
-  static ListeningExecutorService provideExecutorService(CaliperConfig config) {
+  static ListeningExecutorService provideListeningExecutorService() {
+    return MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+  }
+
+  @Binds
+  abstract ExecutorService bindExecutorService(ListeningExecutorService executor);
+
+  @Provides
+  @Singleton
+  @TrialExecutor
+  static ListeningExecutorService provideTrialExecutorService(CaliperConfig config) {
     int poolSize = Integer.parseInt(config.properties().get(RUNNER_MAX_PARALLELISM_OPTION));
     return MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(poolSize));
   }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfig.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfig.java
@@ -109,15 +109,9 @@ public final class CaliperConfig {
           "Missing configuration field: device." + deviceName + ".type");
     }
 
-    DeviceType deviceType = DeviceType.of(deviceTypeField);
-    if (deviceType.equals(DeviceType.ADB)) {
-      // Ok, technically nothing wrong with the configuration, but this is super-temporary anyway
-      throw new InvalidConfigurationException("adb devices are not supported yet");
-    }
-
     return DeviceConfig.builder()
         .name(deviceName)
-        .type(deviceType)
+        .type(DeviceType.of(deviceTypeField))
         .options(subgroupMap(device, "options"))
         .build();
   }

--- a/caliper-runner/src/main/java/com/google/caliper/runner/instrument/InstrumentModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/instrument/InstrumentModule.java
@@ -20,6 +20,7 @@ import com.google.caliper.core.BenchmarkClassModel;
 import com.google.caliper.core.BenchmarkClassModel.MethodModel;
 import com.google.caliper.core.InvalidBenchmarkException;
 import com.google.caliper.core.InvalidInstrumentException;
+import com.google.caliper.runner.RunScoped;
 import com.google.caliper.runner.config.CaliperConfig;
 import com.google.caliper.runner.config.InstrumentConfig;
 import com.google.caliper.runner.config.VmType;
@@ -73,6 +74,7 @@ public abstract class InstrumentModule {
     return new RuntimeInstrument(nanoTimeGranularity);
   }
 
+  @RunScoped
   @Provides
   static ImmutableSet<Instrument> provideInstruments(
       CaliperOptions options,

--- a/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerSocketService.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/server/ServerSocketService.java
@@ -127,7 +127,8 @@ public final class ServerSocketService extends AbstractExecutionThreadService {
   @Inject
   ServerSocketService() {}
 
-  int getPort() {
+  /** Gets the port this server is using. */
+  public int getPort() {
     awaitRunning();
     checkState(serverSocket != null, "Socket has not been opened yet");
     return serverSocket.getLocalPort();

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
@@ -24,7 +24,7 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import dagger.multibindings.IntoSet;
-import javax.inject.Singleton;
+import javax.inject.Provider;
 
 /** Module for providing the {@link Device}. */
 @Module
@@ -39,10 +39,19 @@ public abstract class DeviceModule {
   @Binds
   abstract ShutdownHookRegistrar bindShutdownHookRegistrar(RuntimeShutdownHookRegistrar registrar);
 
-  // only local device supported at the moment
-  @Binds
-  @Singleton
-  abstract Device bindLocalDevice(LocalDevice localDevice);
+  @Provides
+  static Device provideDevice(
+      DeviceConfig config,
+      Provider<LocalDevice> localDeviceProvider,
+      Provider<AdbDevice> adbDeviceProvider) {
+    switch (config.type()) {
+      case LOCAL:
+        return localDeviceProvider.get();
+      case ADB:
+        return adbDeviceProvider.get();
+    }
+    throw new AssertionError(config);
+  }
 
   @Binds
   @IntoSet

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/LocalDevice.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/LocalDevice.java
@@ -33,12 +33,14 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link Device} for the local machine.
  *
  * @author Colin Decker
  */
+@Singleton
 public final class LocalDevice extends Device {
 
   /**

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/ProxyConnectionService.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/ProxyConnectionService.java
@@ -31,7 +31,6 @@ import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.SettableFuture;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.InterruptedException;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -92,6 +91,8 @@ final class ProxyConnectionService extends AbstractExecutionThreadService {
         classpathFuture.set(((RemoteClasspathMessage) message).classpath());
       }
     }
+
+    writer.write(new StopProxyRequest());
   }
 
   /** Returns the classpath to use for processes on the remote device. */
@@ -118,15 +119,7 @@ final class ProxyConnectionService extends AbstractExecutionThreadService {
 
   @Override
   public void shutDown() throws IOException {
-    try {
-      if (writer != null) {
-        writer.write(new StopProxyRequest());
-      }
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
+    closer.close();
   }
 
   /** Proxy for a VM process running on the remote device. */

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/Shell.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/Shell.java
@@ -39,7 +39,7 @@ import javax.inject.Inject;
 final class Shell {
 
   private static final Joiner COMMAND_JOINER = Joiner.on(' ');
-  private static final Splitter COMMAND_SPLITTER = Splitter.on(' ');
+  private static final Splitter COMMAND_SPLITTER = Splitter.on(' ').omitEmptyStrings();
 
   private final ExecutorService executor;
   private final ImmutableMap<String, String> env;

--- a/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialExecutor.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/worker/trial/TrialExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.caliper.runner.worker.trial;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/** Binding annotation for the executor for running trials. */
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface TrialExecutor {}

--- a/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
+++ b/caliper-worker-android/src/main/java/com/google/caliper/worker/CaliperProxyActivity.java
@@ -98,7 +98,7 @@ public final class CaliperProxyActivity extends Activity {
     // TODO(dpb): Maybe some of this could go in a Dagger module (but we probably don't want
     // to be creating files as a side effect in @Provides methods)
     InetSocketAddress runnerAddress =
-        new InetSocketAddress(InetAddress.getLoopbackAddress(), getRunnerPort());
+        new InetSocketAddress(InetAddress.getLocalHost(), getRunnerPort());
     String classpath = AndroidClasspath.getClasspath(getApplicationInfo());
 
     String androidDataDir = System.getProperty("java.io.tmpdir") + "/data";

--- a/caliper-worker/src/main/java/com/google/caliper/worker/WorkerOptionsModule.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/WorkerOptionsModule.java
@@ -25,6 +25,7 @@ import com.google.caliper.util.Util;
 import dagger.Module;
 import dagger.Provides;
 import dagger.Reusable;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Arrays;
@@ -40,11 +41,11 @@ import java.util.UUID;
 final class WorkerOptionsModule {
 
   /** Parses the given command line args to a {@link WorkerOptionsModule}. */
-  public static WorkerOptionsModule fromArgs(String[] args) {
+  public static WorkerOptionsModule fromArgs(String[] args) throws IOException {
     Iterator<String> iter = Arrays.asList(args).iterator();
     return new WorkerOptionsModule(
         UUID.fromString(iter.next()),
-        new InetSocketAddress(InetAddress.getLoopbackAddress(), Integer.parseInt(iter.next())),
+        new InetSocketAddress(InetAddress.getLocalHost(), Integer.parseInt(iter.next())),
         iter.next());
   }
 

--- a/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
@@ -27,7 +27,7 @@ vm.baseDirectory=/usr/local/buildtools/java
 # Standard vm parameter options.
 vm.args=
 
-# Common configurations
+# Common JVM configurations
 
 vm.jdk-32-client.home=jdk-32
 vm.jdk-32-client.args=-d32 -client
@@ -40,6 +40,23 @@ vm.jdk-64-compressed.args=-d64 -XX:+UseCompressedOops
 
 vm.jdk-64-uncompressed.home=jdk-64
 vm.jdk-64-uncompressed.args=-d64 -XX:-UseCompressedOops
+
+# Common Android configurations
+
+vm.dalvikvm.executable=dalvikvm
+vm.dalvikvm.type=android
+
+vm.dalvikvm32.executable=dalvikvm32
+vm.dalvikvm32.type=android
+
+vm.dalvikvm64.executable=dalvikvm64
+vm.dalvikvm64.type=android
+
+vm.art.executable=art
+vm.art.type=android
+
+vm.app_process.executable=app_process
+vm.app_process.type=android
 
 
 ######################

--- a/caliper/src/test/java/com/google/caliper/runner/config/CaliperConfigTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/config/CaliperConfigTest.java
@@ -63,11 +63,11 @@ public class CaliperConfigTest {
 
   @Test
   public void testGetDeviceConfig_nonLocalDevice() {
-    try {
-      DEVICE_TEST_CONFIG.getDeviceConfig("android");
-      fail();
-    } catch (InvalidConfigurationException expected) {
-    }
+    DeviceConfig deviceConfig = DEVICE_TEST_CONFIG.getDeviceConfig("android");
+    assertThat(deviceConfig.name()).isEqualTo("android");
+    assertThat(deviceConfig.type()).isEqualTo(DeviceType.ADB);
+    assertThat(deviceConfig.options()).containsEntry("defaultVmType", "android");
+    assertThat(deviceConfig.options()).doesNotContainKey("vmBaseDirectory");
   }
 
   @Test


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Remove the code blocking device configurations with DeviceType.ADB from being used.

RELNOTES=Caliper can now run benchmarks on Android devices connected via adb.

b6fe119872c119c369622142ff82a8f8588f618d

-------

<p> Add a separate ExecutorService for general stuff that needs an executor and qualify the existing ListeningExecutorService binding with @TrialExecutor because it's an executor with a fixed number of threads related to the configured max parallelism for trials. We don't want other things that need threads to be limited by that.

83856495d51b2dfcffc975971535c4f140cfcaf5

-------

<p> Add common Android VM configurations to the global config for the caliper (not caliper-android) runner, since it will need them too now.

f2faad8afb1945fda8d91dc867ff87699d9e52cf

-------

<p> Use InetAddress.getLocalHost() rather than getLoopbackAddress() for the address that processes on the device side connect to. The loopback address doesn't seem to work with adb reverse, while the localhost address does.

c496afa4788a0c52848be45497e504b901a0b277

-------

<p> Make OpenedSocket.Reader.read() and OpenedSocket.Writer.write() synchronized so that two threads don't try to read or write objects at the same time.

This wasn't an issue in practice before, but it can be an issue now with ProxyConnectionService.

d93e05f4141e6ff16e583dfc513d1f707eb084c7

-------

<p> A number of miscellaneous changes needed to make the new Caliper Android stuff work:

- Enable DeviceModule to bind an AdbDevice instead of a LocalDevice if the configuration is for an adb device.
- Don't try to inject the local port number in AdbDevice; it's a service that wants to start up at the same time as the ServerSocketService, and the Dagger binding for the local port needs to get it from the ServerSocketService once it's started. Instead, inject the ServerSocketService and get the port directly from it once it's started.
- Prevent a message about an instrument type not being usable because a VM doesn't support it from being printed multiple times.
- In ProxyConnectionService, send the request to stop the proxy at the end of run() rather than in shutDown(); when shutDown() is called on it, the ServerSocketService will be shut down or in the process of shutting down and the connection will be broken.
- Make Shell omit empty strings when splitting command lines separated by spaces so that multiple consecutive spaces in a command are treated the same as a single space.

21e9d0ea3f8bd428b431b3856a033d27b6e330be