### PR TITLE
Moe Sync

### DIFF
--- a/caliper-android/src/main/resources/com/google/caliper/runner/config/global-config-local.properties
+++ b/caliper-android/src/main/resources/com/google/caliper/runner/config/global-config-local.properties
@@ -1,0 +1,2 @@
+# Nothing here; only local is supported here anyway, so just use the main
+# global-config.properties file.

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/AdbDevice.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/AdbDevice.java
@@ -23,6 +23,7 @@ import static com.google.common.base.StandardSystemProperty.PATH_SEPARATOR;
 import static com.google.common.base.Strings.nullToEmpty;
 
 import com.google.caliper.bridge.StartVmRequest;
+import com.google.caliper.runner.config.CaliperConfig;
 import com.google.caliper.runner.config.DeviceConfig;
 import com.google.caliper.runner.config.InvalidConfigurationException;
 import com.google.caliper.runner.config.VmConfig;
@@ -60,6 +61,7 @@ final class AdbDevice extends Device {
   private static final String CALIPER_PACKAGE_NAME = "com.google.caliper";
 
   private final CaliperOptions caliperOptions;
+  private final CaliperConfig caliperConfig;
 
   private Shell shell;
   private final String adb = "adb"; // TODO(cgdecker): Make this configurable?
@@ -75,11 +77,13 @@ final class AdbDevice extends Device {
       DeviceConfig config,
       ShutdownHookRegistrar shutdownHookRegistrar,
       CaliperOptions caliperOptions,
+      CaliperConfig caliperConfig,
       Shell shell,
       ServerSocketService server,
       ProxyConnectionService proxyConnection) {
     super(config, shutdownHookRegistrar);
     this.caliperOptions = caliperOptions;
+    this.caliperConfig = caliperConfig;
     this.shell = shell;
     this.server = server;
     this.proxyConnection = proxyConnection;
@@ -239,7 +243,12 @@ final class AdbDevice extends Device {
 
   @Override
   public VmConfig defaultVmConfig() {
-    return VmConfig.builder().name("default").type(ANDROID).executable("dalvikvm").build();
+    return VmConfig.builder()
+        .name("default")
+        .type(ANDROID)
+        .executable("dalvikvm")
+        .addAllArgs(caliperConfig.getVmArgs())
+        .build();
   }
 
   @Override

--- a/caliper/src/main/resources/com/google/caliper/runner/config/global-config-adb.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/global-config-adb.properties
@@ -1,0 +1,35 @@
+##############################################################################
+# VMS
+##############################################################################
+
+vm.dalvikvm.executable=dalvikvm
+vm.dalvikvm.type=android
+
+vm.dalvikvm32.executable=dalvikvm32
+vm.dalvikvm32.type=android
+
+vm.dalvikvm64.executable=dalvikvm64
+vm.dalvikvm64.type=android
+
+vm.art.executable=art
+vm.art.type=android
+
+vm.app_process.executable=app_process
+vm.app_process.type=android
+
+##############################################################################
+# INSTRUMENTS
+##############################################################################
+
+# The default set of instruments (of those defined below) to use if the user
+# does not specify instruments on the command line.
+defaults.instrument=runtime
+
+##############################################################################
+# RUNTIME INSTRUMENT
+##############################################################################
+
+# Overrides for default options from global-config.properties
+instrument.runtime.options.warmup=1s
+instrument.runtime.options.maxWarmupWallTime=1m
+instrument.runtime.options.gcBeforeEach=false

--- a/caliper/src/main/resources/com/google/caliper/runner/config/global-config-local.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/global-config-local.properties
@@ -1,0 +1,52 @@
+##############################################################################
+# VMS
+##############################################################################
+
+# This directory can be automatically prepended to non-absolute VM paths
+vm.baseDirectory=/usr/local/buildtools/java
+
+# Standard vm parameter options.
+vm.args=
+
+# Common JVM configurations
+
+vm.jdk-32-client.home=jdk-32
+vm.jdk-32-client.args=-d32 -client
+
+vm.jdk-32-server.home=jdk-32
+vm.jdk-32-server.args=-d32 -server
+
+vm.jdk-64-compressed.home=jdk-64
+vm.jdk-64-compressed.args=-d64 -XX:+UseCompressedOops
+
+vm.jdk-64-uncompressed.home=jdk-64
+vm.jdk-64-uncompressed.args=-d64 -XX:-UseCompressedOops
+
+##############################################################################
+# INSTRUMENTS
+##############################################################################
+
+# The default set of instruments (of those defined below) to use if the user
+# does not specify instruments on the command line.
+defaults.instrument=allocation,runtime
+
+##############################################################################
+# ARBITRARY MEASUREMENT INSTRUMENT
+##############################################################################
+
+instrument.arbitrary.class=com.google.caliper.runner.instrument.ArbitraryMeasurementInstrument
+
+# Run GC before every measurement?
+instrument.arbitrary.options.gcBeforeEach=false
+
+##############################################################################
+# ALLOCATION INSTRUMENT
+##############################################################################
+
+instrument.allocation.class=com.google.caliper.runner.instrument.AllocationInstrument
+
+# Track and log a summary of every individual allocation.  This enables better error messages for
+# buggy benchmarks and prints detailed reports of allocation behavior in verbose mode.  N.B. This
+# can increase the memory usage of the allocation worker significantly, so it is not recommended
+# for benchmarks that do a lot of allocation.
+instrument.allocation.options.trackAllocations=false

--- a/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
+++ b/caliper/src/main/resources/com/google/caliper/runner/config/global-config.properties
@@ -1,9 +1,9 @@
 # Caliper global config file for the JVM platform
 # Users' ~/.caliper/config settings may override these
 
-######################
-# DEVICE CONFIGURATION
-######################
+##############################################################################
+# DEVICES
+##############################################################################
 
 device.local.type=local
 device.local.options.defaultVmType=jvm
@@ -17,61 +17,18 @@ device.android-device.options.selector=-d
 device.android-emulator.type=adb
 device.android-emulator.options.selector=-e
 
-######################
-# VM CONFIGURATION
-######################
-
-# This directory can be automatically prepended to non-absolute VM paths
-vm.baseDirectory=/usr/local/buildtools/java
-
-# Standard vm parameter options.
-vm.args=
-
-# Common JVM configurations
-
-vm.jdk-32-client.home=jdk-32
-vm.jdk-32-client.args=-d32 -client
-
-vm.jdk-32-server.home=jdk-32
-vm.jdk-32-server.args=-d32 -server
-
-vm.jdk-64-compressed.home=jdk-64
-vm.jdk-64-compressed.args=-d64 -XX:+UseCompressedOops
-
-vm.jdk-64-uncompressed.home=jdk-64
-vm.jdk-64-uncompressed.args=-d64 -XX:-UseCompressedOops
-
-# Common Android configurations
-
-vm.dalvikvm.executable=dalvikvm
-vm.dalvikvm.type=android
-
-vm.dalvikvm32.executable=dalvikvm32
-vm.dalvikvm32.type=android
-
-vm.dalvikvm64.executable=dalvikvm64
-vm.dalvikvm64.type=android
-
-vm.art.executable=art
-vm.art.type=android
-
-vm.app_process.executable=app_process
-vm.app_process.type=android
-
-
-######################
-# INSTRUMENT CONFIG
-######################
-
-# The default set of instruments (of those defined below) to use if the user
-# does not specify instruments on the command line.
-defaults.instrument=allocation,runtime
+##############################################################################
+# INSTRUMENTS
+##############################################################################
 
 # To define new instrument configurations, provide an "instrument.<name>.class" property
 # pointing to a concrete class that extends com.google.caliper.runner.instrument.Instrument, and add
 # whichever other options it supports using "instrument.<name>.<optionName>=<value>".
 
-# Instrument "runtime"
+##############################################################################
+# RUNTIME INSTRUMENT
+##############################################################################
+
 instrument.runtime.class=com.google.caliper.runner.instrument.RuntimeInstrument
 
 # Do not report any measurements from before this minimum time has elapsed
@@ -97,28 +54,16 @@ instrument.runtime.options.gcBeforeEach=true
 # take proper measurements due to granularity issues.
 instrument.runtime.options.suggestGranularity=true
 
-# Instrument "arbitrary"
-instrument.arbitrary.class=com.google.caliper.runner.instrument.ArbitraryMeasurementInstrument
-
-# Run GC before every measurement?
-instrument.arbitrary.options.gcBeforeEach=false
-
-# Instrument "allocation"
-instrument.allocation.class=com.google.caliper.runner.instrument.AllocationInstrument
-
-# Track and log a summary of every individual allocation.  This enables better error messages for
-# buggy benchmarks and prints detailed reports of allocation behavior in verbose mode.  N.B. This
-# can increase the memory usage of the allocation worker significantly, so it is not recommended
-# for benchmarks that do a lot of allocation.
-instrument.allocation.options.trackAllocations=false
-
+##############################################################################
+# MISC
+##############################################################################
 
 # Sets the maximum number of trials that can run in parallel.
 runner.maxParallelism=2
 
-######################
-# RESULTS PROCESSORS
-######################
+##############################################################################
+# RESULT PROCESSORS
+##############################################################################
 
 results.file.class=com.google.caliper.runner.resultprocessor.OutputFileDumper
 

--- a/caliper/src/test/java/com/google/caliper/runner/config/CaliperConfigModuleTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/config/CaliperConfigModuleTest.java
@@ -59,6 +59,7 @@ public class CaliperConfigModuleTest {
 
   @Test
   public void loadOrCreate_configFileExistsNoOverride() throws Exception {
+    when(optionsMock.deviceName()).thenReturn("local");
     when(optionsMock.caliperConfigFile()).thenReturn(tempConfigFile);
     when(optionsMock.configProperties()).thenReturn(ImmutableMap.<String, String>of());
     CaliperConfig config = CaliperConfigModule.caliperConfig(optionsMock, loggingConfigLoader);
@@ -67,6 +68,7 @@ public class CaliperConfigModuleTest {
 
   @Test
   public void loadOrCreate_configFileExistsWithOverride() throws Exception {
+    when(optionsMock.deviceName()).thenReturn("local");
     when(optionsMock.caliperConfigFile()).thenReturn(tempConfigFile);
     when(optionsMock.configProperties()).thenReturn(ImmutableMap.of("some.property", "tacos"));
     CaliperConfig config = CaliperConfigModule.caliperConfig(optionsMock, loggingConfigLoader);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add vm.args to the default VmConfig for AdbDevice. This is needed to be consistent with LocalDevice, which does this for its default VmConfig, and also to be consistent with any named VM, which would also get vm.args added (it's surprising to go from having the default, which should be dalvikvm, succeed, to "-m dalvikvm" and have it fail because it got too large a -Xms/x).

0d3add430ef7e165009e35e5d732bea7ad96e90f

-------

<p> Split global-config.properties into three: global-config.properties, global-config-local.properties and global-config-adb.properties.

This allows there to be different global defaults for various things between local and Android devices, which solves some of our configuration related issues:

- The default set of instruments is only "runtime" for Android devices since that's all that Android VMs support.
- The default options for the runtime instrument are different for Android devices.

It doesn't solve probably the biggest issue, which is the default vm.args value of "-Xms3g -Xmx3g", because that's set in the user's local configuration file. But that at least is pretty easy to override via the command line. I may try to solve that by doing something similar to what I've done for the global config here for the user config as well.

0e64ec4262e518b834b72b8ac6e4d72bcedd77d5