### PR TITLE
Moe Sync

### DIFF
--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfigModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/CaliperConfigModule.java
@@ -53,7 +53,7 @@ public abstract class CaliperConfigModule {
     // Create a CaliperConfig using just those options. They should contain all the information we
     // need to get get the type of device this run is targeting.
     CaliperConfig config = merge(globalConfig, userConfig, commandLineConfig);
-    DeviceType deviceType = config.getDeviceConfig(caliperOptions.deviceName()).type();
+    DeviceType deviceType = config.getDeviceConfig(caliperOptions).type();
 
     // Get the global config for the device type (e.g. "global-config-adb.properties").
     ImmutableMap<String, String> globalDeviceTypeConfig = loadGlobalConfig("-" + deviceType);

--- a/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
@@ -208,7 +208,7 @@ public final class ParsedOptions implements CaliperOptions {
   // Device
   // --------------------------------------------------------------------------
 
-  private String deviceName = "local";
+  private String deviceName = "default";
 
   @Option({"-e", "--device"})
   private void setDeviceName(String deviceName) {

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/DeviceModule.java
@@ -33,7 +33,7 @@ public abstract class DeviceModule {
 
   @Provides
   static DeviceConfig provideDeviceConfig(CaliperOptions options, CaliperConfig config) {
-    return config.getDeviceConfig(options.deviceName());
+    return config.getDeviceConfig(options);
   }
 
   @Binds

--- a/caliper-runner/src/main/java/com/google/caliper/runner/target/VmProcess.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/target/VmProcess.java
@@ -59,7 +59,6 @@ public abstract class VmProcess {
   /** Attempts to kill the process. */
   public final void kill() {
     doKill();
-    stopped();
   }
 
   /** Attempts to kill the process. */

--- a/caliper/src/test/java/com/google/caliper/runner/target/LocalDeviceTest.java
+++ b/caliper/src/test/java/com/google/caliper/runner/target/LocalDeviceTest.java
@@ -17,7 +17,6 @@
 package com.google.caliper.runner.target;
 
 import static com.google.common.truth.Truth.assertThat;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -123,17 +122,6 @@ public class LocalDeviceTest {
     assertEquals(
         "worker-shutdown-hook-" + spec.id(), Iterables.getOnlyElement(registrar.hooks).getName());
     worker.awaitExit();
-    assertTrue(registrar.hooks.isEmpty());
-  }
-
-  @Test
-  public void shutdownHook_kill() throws Exception {
-    WorkerSpec spec =
-        FakeWorkerSpec.builder(FakeWorkers.Sleeper.class)
-            .setArgs(Long.toString(MINUTES.toMillis(1)))
-            .build();
-    VmProcess worker = device.startVm(spec, new NullLogger());
-    worker.kill();
     assertTrue(registrar.hooks.isEmpty());
   }
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't call stopped() from VmProcess.kill().

The main reason for this change is to fix an issue where one or more exceptions were thrown when you ctrl-C'd Caliper; the shutdown hook thread for each active worker process would run, which would call kill() on the process; if kill() then called stopped(), the listener would try to remove the shutdown hook for the process, which would throw an exception from Runtime.removeShutdownHook because shutdown was already in process.

This is also more consistent with Process.destroy(), which doesn't wait for the process to exit; as such it wasn't even necessarily true that the process was stopped when stopped() was called, just that we'd asked it to stop.

7fefc2ba06d910cf620db463526cbf661884ff03

-------

<p> Allow users to not specify a device on the command line for Android benchmarks as well as for JVM benchmarks.

Basically, the default device will still be "local" in general, but when no device is specified and --worker-classpath-android *is* specified, the default device will instead be "android" (i.e. the single adb-connected device or emulator, failing if more than one is present).

Primarily, this means that users of android_benchmarks will not *always* need to provide a device on the command line.

390b50de66ca9d42f9d705689a515f7627b490d8