### PR TITLE
Moe Sync

### DIFF
--- a/caliper-runner/src/main/java/com/google/caliper/runner/options/CaliperOptions.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/options/CaliperOptions.java
@@ -100,6 +100,9 @@ public interface CaliperOptions {
   /** Returns the user's Caliper configuration file. */
   File caliperConfigFile();
 
+  /** Returns additional arguments to pass to ADB commands. */
+  ImmutableList<String> adbArgs();
+
   /**
    * Returns whether or not the worker log file content should be printed when a worker fails. By
    * default (false), just the path to the log file is printed.

--- a/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/options/ParsedOptions.java
@@ -392,6 +392,24 @@ public final class ParsedOptions implements CaliperOptions {
   }
 
   // --------------------------------------------------------------------------
+  // ADB args, for use by AdbDevice
+  // --------------------------------------------------------------------------
+
+  private ImmutableList<String> adbArgs = ImmutableList.of();
+
+  @Option("--adb-args")
+  private void setAdbArgs(String args) {
+    // Don't use the delimiter that's used for other options here; it's "," by default, which
+    // seems surprising for an option that is a series of command line args.
+    adbArgs = ImmutableList.copyOf(Splitter.on(' ').split(args));
+  }
+
+  @Override
+  public ImmutableList<String> adbArgs() {
+    return adbArgs;
+  }
+
+  // --------------------------------------------------------------------------
   // Miscellaneous
   // --------------------------------------------------------------------------
 
@@ -520,6 +538,11 @@ public final class ParsedOptions implements CaliperOptions {
           "                    provided and the benchmark is running on the local device, the ",
           "                    classpath of the runner process may be used as a default. This is ",
           "                    for compatibility reasons and may not be supported in the future.",
+          " --adb-args         additional arguments to pass to adb when using an adb-connected ",
+          "                    device. This is primarily intended for use with things like -P ",
+          "                    (setting the port to use for the adb instance); while it could ",
+          "                    also be used for args such as -d that select the device to use, ",
+          "                    prefer using --device for that.",
           " --print-worker-log if an error occurs in a worker, print the log for that worker ",
           "                    rather than the path to the log file; primarily for use in tests ",
           "                    when running in a CI environment where the log files may not be ",


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add --adb-args command line option for Caliper. It just specifies additional args to pass to adb each time it's called.

Aside from giving users more control, this will probably be needed for implementing tests that dry-run benchmarks on an emulator, since we'll need to specify the port for connecting to the adb instance the emulator is connected to.

70b6794a5294cac9a3a0014750c05575672f0b49