### PR TITLE
Moe Sync

### DIFF
--- a/caliper-core/src/main/java/com/google/caliper/core/UserCodeException.java
+++ b/caliper-core/src/main/java/com/google/caliper/core/UserCodeException.java
@@ -19,6 +19,10 @@ import java.io.PrintWriter;
 /** Signifies that the user's benchmark code threw an exception. */
 @SuppressWarnings("serial")
 public class UserCodeException extends InvalidBenchmarkException {
+  public UserCodeException(String message) {
+    super(message);
+  }
+
   public UserCodeException(String message, Throwable cause) {
     super(message);
     initCause(cause);

--- a/caliper-runner/src/main/java/com/google/caliper/runner/config/ResultProcessorConfig.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/config/ResultProcessorConfig.java
@@ -69,7 +69,7 @@ public class ResultProcessorConfig {
         .toString();
   }
 
-  static final class Builder {
+  public static final class Builder {
     private String className;
     private ImmutableMap.Builder<String, String> optionsBuilder = ImmutableMap.builder();
 

--- a/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/ResultProcessorModule.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/ResultProcessorModule.java
@@ -61,7 +61,8 @@ public abstract class ResultProcessorModule {
       Provider<ResultProcessor> resultProcessorProvider = availableProcessors.get(processorClass);
       ResultProcessor resultProcessor =
           resultProcessorProvider == null
-              ? ResultProcessorCreator.createResultProcessor(processorClass)
+              ? ResultProcessorCreator.createResultProcessor(
+                  processorClass, config.getResultProcessorConfig(processorClass))
               : resultProcessorProvider.get();
       builder.add(resultProcessor);
     }

--- a/caliper-runner/src/test/java/com/google/caliper/runner/resultprocessor/ResultProcessorCreatorTest.java
+++ b/caliper-runner/src/test/java/com/google/caliper/runner/resultprocessor/ResultProcessorCreatorTest.java
@@ -16,6 +16,7 @@
 
 package com.google.caliper.runner.resultprocessor;
 
+import static com.google.caliper.runner.resultprocessor.ResultProcessorCreator.NO_VALID_CONSTRUCTOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -23,6 +24,7 @@ import static org.junit.Assert.fail;
 import com.google.caliper.api.ResultProcessor;
 import com.google.caliper.core.UserCodeException;
 import com.google.caliper.model.Trial;
+import com.google.caliper.runner.config.ResultProcessorConfig;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,17 +34,25 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ResultProcessorCreatorTest {
 
-  public static final String NOT_SUPPORTED =
-      "ResultProcessor %s not supported as it does not have a public default constructor";
+  private static ResultProcessor createProcessor(Class<? extends ResultProcessor> processorClass) {
+    return ResultProcessorCreator.createResultProcessor(processorClass, config(processorClass));
+  }
+
+  private static ResultProcessorConfig config(Class<? extends ResultProcessor> processorClass) {
+    return new ResultProcessorConfig.Builder()
+        .className(processorClass.getName())
+        .build();
+  }
 
   @Test
   public void testNotPublicConstructor() {
     try {
-      ResultProcessorCreator.createResultProcessor(NoPublicConstructorResultProcessor.class);
+      createProcessor(NoPublicConstructorResultProcessor.class);
       fail("Did not fail on non-public constructor");
     } catch (UserCodeException e) {
       assertEquals(
-          String.format(NOT_SUPPORTED, NoPublicConstructorResultProcessor.class), e.getMessage());
+          String.format(NO_VALID_CONSTRUCTOR, NoPublicConstructorResultProcessor.class),
+          e.getMessage());
     }
   }
 
@@ -60,12 +70,12 @@ public class ResultProcessorCreatorTest {
   @Test
   public void testPublicButNotDefaultConstructor() {
     try {
-      ResultProcessorCreator.createResultProcessor(
-          PublicButNotDefaultDefaultConstructorResultProcessor.class);
+      createProcessor(PublicButNotDefaultDefaultConstructorResultProcessor.class);
       fail("Did not fail on public but not default constructor");
     } catch (UserCodeException e) {
       assertEquals(
-          String.format(NOT_SUPPORTED, PublicButNotDefaultDefaultConstructorResultProcessor.class),
+          String.format(
+              NO_VALID_CONSTRUCTOR, PublicButNotDefaultDefaultConstructorResultProcessor.class),
           e.getMessage());
     }
   }
@@ -85,12 +95,51 @@ public class ResultProcessorCreatorTest {
 
   @Test
   public void testPublicConstructor() {
-    ResultProcessor processor =
-        ResultProcessorCreator.createResultProcessor(PublicDefaultConstructorResultProcessor.class);
+    ResultProcessor processor = createProcessor(PublicDefaultConstructorResultProcessor.class);
     assertTrue(processor instanceof PublicDefaultConstructorResultProcessor);
   }
 
   public static class PublicDefaultConstructorResultProcessor implements ResultProcessor {
+
+    @Override
+    public void processTrial(Trial trial) {}
+
+    @Override
+    public void close() throws IOException {}
+  }
+
+  @Test
+  public void testNotPublicConfigConstructor() {
+    try {
+      createProcessor(NoPublicConfigConstructorResultProcessor.class);
+      fail("Did not fail on non-public constructor");
+    } catch (UserCodeException e) {
+      assertEquals(
+          String.format(NO_VALID_CONSTRUCTOR, NoPublicConfigConstructorResultProcessor.class),
+          e.getMessage());
+    }
+  }
+
+  public static class NoPublicConfigConstructorResultProcessor implements ResultProcessor {
+
+    NoPublicConfigConstructorResultProcessor(ResultProcessorConfig config) {}
+
+    @Override
+    public void processTrial(Trial trial) {}
+
+    @Override
+    public void close() throws IOException {}
+  }
+
+  @Test
+  public void testPublicConfigConstructor() {
+    ResultProcessor processor = createProcessor(PublicConfigConstructorResultProcessor.class);
+    assertTrue(processor instanceof PublicConfigConstructorResultProcessor);
+  }
+
+  public static class PublicConfigConstructorResultProcessor implements ResultProcessor {
+
+    public PublicConfigConstructorResultProcessor(ResultProcessorConfig config) {}
 
     @Override
     public void processTrial(Trial trial) {}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Allow custom ResultProcessors to take their ResultProcessorConfig as a constructor parameter.

This is needed now because it isn't easy to add a binding to Dagger for a custom ResultProcessor to have its constructor injected like was done when using Guice before.

RELNOTES=Allow user-defined `ResultProcessor`s to have a constructor taking a `ResultProcessorConfig`.

8630008f9593139ea2f12418364c00b8c6821632