### PR TITLE
Moe Sync

### DIFF
--- a/caliper-worker/src/main/java/com/google/caliper/worker/handler/HostDevice.java
+++ b/caliper-worker/src/main/java/com/google/caliper/worker/handler/HostDevice.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
@@ -119,8 +118,8 @@ abstract class HostDevice {
       Class<?> androidOsBuildClass =
           ClassLoader.getSystemClassLoader().loadClass("android.os.Build");
       if (androidOsBuildClass != null) {
-        Field fingerprint = androidOsBuildClass.getDeclaredField("FINGERPRINT");
-        propertyMap.put("host.android.buildFingerprint", (String) fingerprint.get(null));
+        String fingerprint = (String) androidOsBuildClass.getDeclaredField("FINGERPRINT").get(null);
+        propertyMap.put("host.android.buildFingerprint", fingerprint != null ? fingerprint : "");
       }
     } catch (ReflectiveOperationException e) {
       // Not Android; ignore.


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Add Android build fingerprint to Caliper metadata.

For Android, this is more descriptive than os.version, os.arch, and the
(currently unused) java.version.  Because of ongoing ART improvements,
the build fingerprint is needed to interpret runtime results.

RELNOTES=add Android build fingerprint to scenario metadata.

e833e6e9cc050c7e40076728cab63fb104705a39

-------

<p> Tolerate null reference for android.os.Build#FINGERPRINT.

It's not expected to be null on a real Android device, but could be on a
mocked-out version.

9ff9ef00eeb2beded9db15a35a7308a5fe317158