### PR TITLE
Change method name 'display' to 'printUsage'

### DIFF
--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunner.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunner.java
@@ -95,10 +95,10 @@ public final class CaliperRunner {
       runInternal();
       code = 0;
     } catch (DisplayUsageException e) {
-      e.display(stdout);
+      e.printUsage(stdout);
       code = e.exitCode();
     } catch (InvalidCommandException e) {
-      e.display(stderr);
+      e.printUsage(stderr);
       code = e.exitCode();
     } catch (InvalidBenchmarkException e) {
       e.display(stderr);

--- a/caliper-util/src/main/java/com/google/caliper/util/DisplayUsageException.java
+++ b/caliper-util/src/main/java/com/google/caliper/util/DisplayUsageException.java
@@ -27,7 +27,7 @@ public final class DisplayUsageException extends InvalidCommandException {
   }
 
   @Override
-  public void display(PrintWriter writer) {
+  public void printUsage(PrintWriter writer) {
     displayUsage(writer);
   }
 

--- a/caliper-util/src/main/java/com/google/caliper/util/InvalidCommandException.java
+++ b/caliper-util/src/main/java/com/google/caliper/util/InvalidCommandException.java
@@ -31,7 +31,7 @@ public class InvalidCommandException extends RuntimeException {
     this.usage = ImmutableList.copyOf(usage);
   }
 
-  public void display(PrintWriter writer) {
+  public void printUsage(PrintWriter writer) {
     writer.println(getMessage());
     if (usage != null) {
       writer.println();


### PR DESCRIPTION
This class is used to represent InvalidCommandException.  This method named 'display' is to print usage. Thus, the method name 'printUsage' is more intuitive than 'display'.