### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 before_install:
   # Travis sets this and it causes issues with workers.

--- a/caliper-core/pom.xml
+++ b/caliper-core/pom.xml
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
+      <artifactId>auto-value-annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/caliper-runner/pom.xml
+++ b/caliper-runner/pom.xml
@@ -72,7 +72,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value</artifactId>
+      <artifactId>auto-value-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.8.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value</artifactId>
+        <artifactId>auto-value-annotations</artifactId>
         <version>${autovalue.version}</version>
       </dependency>
       <dependency>
@@ -176,7 +176,7 @@
             <source>1.8</source>
             <target>1.8</target>
             <annotationProcessorPaths>
-               <path>
+              <path>
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value</artifactId>
                 <version>${autovalue.version}</version>
@@ -185,6 +185,12 @@
                 <groupId>com.google.dagger</groupId>
                 <artifactId>dagger-compiler</artifactId>
                 <version>${dagger.version}</version>
+              </path>
+              <!-- TODO(cpovirk): Remove this after updating AutoValue's dep. -->
+              <path>
+                <groupId>com.squareup</groupId>
+                <artifactId>javapoet</artifactId>
+                <version>1.11.1</version>
               </path>
             </annotationProcessorPaths>
           </configuration>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Travis: openjdk8, openjdk11

Fixes #417
Should help with the problem mentioned in the discussion on #420

ae31138c92f4479b6e9e0342c7d9dfb2bd030665

-------

<p> maven-compiler-plugin 3.8.1

Fixes #416
Should help with the problem mentioned in the discussion on #420

8e6ff19fa16ca343af2c813b9a76ce588e63116a

-------

<p> Fix compile breakages from CL 272485203:

1. AutoValue depends on an older version of JavaPoet than Dagger does, but Maven picks AutoValue's version, so Dagger sees:

java.lang.NoSuchMethodError: com.squareup.javapoet.ClassName.withoutAnnotations()Lcom/squareup/javapoet/ClassName;

(I thought at one point that there was a real problem with JavaPoet's binary compatibility, but I was wrong: https://github.com/square/javapoet/issues/741)

2. The newer version of AutoValue is split into auto-value and auto-value-annotations. Our compile dependencies need to be on the latter.

7f6c128b56d11774423861e3e0d75c9e81812b96