### PR TITLE
MOE Sync 2020-03-30

### DIFF
--- a/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunner.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/CaliperRunner.java
@@ -16,6 +16,7 @@
 
 package com.google.caliper.runner;
 
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.common.util.concurrent.MoreExecutors.shutdownAndAwaitTermination;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -148,7 +149,8 @@ public final class CaliperRunner {
                   stderr.println("Service " + service + " failed with the following exception:");
                   service.failureCause().printStackTrace(stderr);
                 }
-              });
+              },
+              directExecutor());
       serviceManager.get().startAsync().awaitHealthy();
       try {
         TargetInfo targetInfo = targetInfoFactory.get().getTargetInfo();


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate from soon-to-be-deprecated addListener(listener) to equivalent addListener(listener, directExecutor()).

The 1-arg overload is being removed: directExecutor() is often useful, but it should be an explicit choice, as some usages are dangerous:
https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/util/concurrent/ListenableFuture.html#addListener-java.lang.Runnable-java.util.concurrent.Executor-

ef772c0dc891ff994309433e8e90ad01531c4d32