### PR TITLE
Fix spelling of occurred in OutputFileDumper log message

### DIFF
--- a/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/OutputFileDumper.java
+++ b/caliper-runner/src/main/java/com/google/caliper/runner/resultprocessor/OutputFileDumper.java
@@ -112,7 +112,7 @@ public final class OutputFileDumper implements ResultProcessor {
         logger.log(
             SEVERE,
             String.format(
-                "An error occured writing trial %s. Results in %s will be incomplete.",
+                "An error occurred writing trial %s. Results in %s will be incomplete.",
                 trial.id(), resultFile),
             e);
       }


### PR DESCRIPTION
## Summary
- Correct `occured` → `occurred` in the `OutputFileDumper` error log message.

## Test plan
- [x] Spelling-only change in a log string; no behavior change.